### PR TITLE
Fix Build Headaches

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Log in to the build VM and set up the Omnibus build infrastructure.
 ```
 vagrant ssh
 cd /vagrant/builders/flight-example
-bundle install --path=vendor --binstubs
+bundle install
 ```
 
 ## Building a project

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,10 +26,7 @@
 #===============================================================================
 Vagrant.configure("2") do |config|
   config.vm.box = "bento/centos-7.6"
-  config.vm.box_version = "201812.27.0"
   code_path = ENV['FLIGHT_CODE'] || "#{ENV['HOME']}/code"
-
-  config.vm.box = "bento/centos-7.6"
 
   config.vm.define "default", primary: true do |build|
     build.vm.provision "shell", path: "vagrant/provision.sh"

--- a/builders/flight-architect/.bundle/config
+++ b/builders/flight-architect/.bundle/config
@@ -1,0 +1,3 @@
+---
+BUNDLE_PATH: "/home/vagrant/flight-architect/vendor"
+BUNDLE_BIN: "bin"

--- a/builders/flight-architect/.gitignore
+++ b/builders/flight-architect/.gitignore
@@ -1,5 +1,4 @@
 *.gem
-.bundle
 .kitchen/
 .kitchen.local.yml
 pkg/*

--- a/builders/flight-architect/omnibus.rb
+++ b/builders/flight-architect/omnibus.rb
@@ -39,7 +39,7 @@
 #
 # Uncomment this line to change the default base directory to "local"
 # -------------------------------------------------------------------
-base_dir './local'
+base_dir '/home/vagrant/flight-architect/local'
 #
 # Alternatively you can tune the individual values
 # ------------------------------------------------

--- a/builders/flight-cloud-client/.bundle/config
+++ b/builders/flight-cloud-client/.bundle/config
@@ -1,0 +1,3 @@
+---
+BUNDLE_PATH: "/home/vagrant/flight-cloud-client/vendor"
+BUNDLE_BIN: "bin"

--- a/builders/flight-cloud-client/.gitignore
+++ b/builders/flight-cloud-client/.gitignore
@@ -1,5 +1,4 @@
 *.gem
-.bundle
 .kitchen/
 .kitchen.local.yml
 pkg/*

--- a/builders/flight-cloud-client/config/projects/flight-cloud-client.rb
+++ b/builders/flight-cloud-client/config/projects/flight-cloud-client.rb
@@ -31,7 +31,7 @@ friendly_name 'Flight Cloud Client'
 
 install_dir '/opt/flight/opt/cloud'
 
-build_version '0.0.2'
+build_version '0.1.0'
 build_iteration 1
 
 dependency 'preparation'

--- a/builders/flight-cloud-client/config/software/flight-cloud-client.rb
+++ b/builders/flight-cloud-client/config/software/flight-cloud-client.rb
@@ -25,7 +25,7 @@
 # https://github.com/openflighthpc/openflight-omnibus-builder
 #===============================================================================
 name 'flight-cloud-client'
-default_version '0.0.2'
+default_version '0.1.0'
 
 source git: 'https://github.com/openflighthpc/flight-cloud-client'
 

--- a/builders/flight-cloud-client/omnibus.rb
+++ b/builders/flight-cloud-client/omnibus.rb
@@ -39,7 +39,7 @@
 #
 # Uncomment this line to change the default base directory to "local"
 # -------------------------------------------------------------------
-base_dir './local'
+base_dir '/home/vagrant/flight-cloud-client/local'
 #
 # Alternatively you can tune the individual values
 # ------------------------------------------------

--- a/builders/flight-cloud/.bundle/config
+++ b/builders/flight-cloud/.bundle/config
@@ -1,0 +1,3 @@
+---
+BUNDLE_PATH: "/home/vagrant/flight-cloud/vendor"
+BUNDLE_BIN: "bin"

--- a/builders/flight-cloud/.gitignore
+++ b/builders/flight-cloud/.gitignore
@@ -1,5 +1,4 @@
 *.gem
-.bundle
 .kitchen/
 .kitchen.local.yml
 pkg/*

--- a/builders/flight-cloud/config/projects/flight-cloud.rb
+++ b/builders/flight-cloud/config/projects/flight-cloud.rb
@@ -31,7 +31,7 @@ friendly_name 'Flight Cloud'
 
 install_dir '/opt/flight/opt/cloud'
 
-build_version '1.2.4'
+build_version '2.1.0'
 build_iteration 1
 
 dependency 'preparation'

--- a/builders/flight-cloud/config/software/flight-cloud.rb
+++ b/builders/flight-cloud/config/software/flight-cloud.rb
@@ -25,7 +25,7 @@
 # https://github.com/openflighthpc/openflight-omnibus-builder
 #===============================================================================
 name 'flight-cloud'
-default_version '1.2.4'
+default_version '2.1.0'
 
 source git: 'https://github.com/openflighthpc/flight-cloud'
 

--- a/builders/flight-cloud/omnibus.rb
+++ b/builders/flight-cloud/omnibus.rb
@@ -39,7 +39,7 @@
 #
 # Uncomment this line to change the default base directory to "local"
 # -------------------------------------------------------------------
-base_dir './local'
+base_dir '/home/vagrant/flight-cloud/local'
 #
 # Alternatively you can tune the individual values
 # ------------------------------------------------

--- a/builders/flight-hunter/.bundle/config
+++ b/builders/flight-hunter/.bundle/config
@@ -1,0 +1,3 @@
+---
+BUNDLE_PATH: "/home/vagrant/flight-hunter/vendor"
+BUNDLE_BIN: "bin"

--- a/builders/flight-hunter/.gitignore
+++ b/builders/flight-hunter/.gitignore
@@ -1,5 +1,4 @@
 *.gem
-.bundle
 .kitchen/
 .kitchen.local.yml
 pkg/*

--- a/builders/flight-hunter/omnibus.rb
+++ b/builders/flight-hunter/omnibus.rb
@@ -39,7 +39,7 @@
 #
 # Uncomment this line to change the default base directory to "local"
 # -------------------------------------------------------------------
-base_dir './local'
+base_dir '/home/vagrant/flight-hunter/local'
 #
 # Alternatively you can tune the individual values
 # ------------------------------------------------

--- a/builders/flight-inventory/.bundle/config
+++ b/builders/flight-inventory/.bundle/config
@@ -1,0 +1,3 @@
+---
+BUNDLE_PATH: "/home/vagrant/flight-inventory/vendor"
+BUNDLE_BIN: "bin"

--- a/builders/flight-inventory/.gitignore
+++ b/builders/flight-inventory/.gitignore
@@ -1,5 +1,4 @@
 *.gem
-.bundle
 .kitchen/
 .kitchen.local.yml
 pkg/*

--- a/builders/flight-inventory/omnibus.rb
+++ b/builders/flight-inventory/omnibus.rb
@@ -39,7 +39,7 @@
 #
 # Uncomment this line to change the default base directory to "local"
 # -------------------------------------------------------------------
-base_dir './local'
+base_dir '/home/vagrant/flight-inventory/local'
 #
 # Alternatively you can tune the individual values
 # ------------------------------------------------

--- a/builders/flight-manage/.bundle/config
+++ b/builders/flight-manage/.bundle/config
@@ -1,0 +1,3 @@
+---
+BUNDLE_PATH: "/home/vagrant/flight-manage/vendor"
+BUNDLE_BIN: "bin"

--- a/builders/flight-manage/.gitignore
+++ b/builders/flight-manage/.gitignore
@@ -1,5 +1,4 @@
 *.gem
-.bundle
 .kitchen/
 .kitchen.local.yml
 pkg/*

--- a/builders/flight-manage/omnibus.rb
+++ b/builders/flight-manage/omnibus.rb
@@ -39,7 +39,7 @@
 #
 # Uncomment this line to change the default base directory to "local"
 # -------------------------------------------------------------------
-base_dir './local'
+base_dir '/home/vagrant/flight-manage/local'
 #
 # Alternatively you can tune the individual values
 # ------------------------------------------------

--- a/builders/flight-message/.bundle/config
+++ b/builders/flight-message/.bundle/config
@@ -1,0 +1,3 @@
+---
+BUNDLE_PATH: "/home/vagrant/flight-message/vendor"
+BUNDLE_BIN: "bin"

--- a/builders/flight-message/.gitignore
+++ b/builders/flight-message/.gitignore
@@ -1,5 +1,4 @@
 *.gem
-.bundle
 .kitchen/
 .kitchen.local.yml
 pkg/*

--- a/builders/flight-message/omnibus.rb
+++ b/builders/flight-message/omnibus.rb
@@ -39,7 +39,7 @@
 #
 # Uncomment this line to change the default base directory to "local"
 # -------------------------------------------------------------------
-base_dir './local'
+base_dir '/home/vagrant/flight-message/local'
 #
 # Alternatively you can tune the individual values
 # ------------------------------------------------

--- a/builders/flight-metal/.bundle/config
+++ b/builders/flight-metal/.bundle/config
@@ -1,0 +1,3 @@
+---
+BUNDLE_PATH: "/home/vagrant/flight-metal/vendor"
+BUNDLE_BIN: "bin"

--- a/builders/flight-metal/.gitignore
+++ b/builders/flight-metal/.gitignore
@@ -1,5 +1,4 @@
 *.gem
-.bundle
 .kitchen/
 .kitchen.local.yml
 pkg/*

--- a/builders/flight-metal/config/projects/flight-metal.rb
+++ b/builders/flight-metal/config/projects/flight-metal.rb
@@ -31,7 +31,7 @@ friendly_name 'Flight Metal'
 
 install_dir '/opt/flight/opt/metal'
 
-build_version '0.1.3'
+build_version '0.3.3'
 build_iteration 1
 
 dependency 'preparation'

--- a/builders/flight-metal/config/software/flight-metal.rb
+++ b/builders/flight-metal/config/software/flight-metal.rb
@@ -25,7 +25,7 @@
 # https://github.com/openflighthpc/openflight-omnibus-builder
 #===============================================================================
 name 'flight-metal'
-default_version '0.1.3'
+default_version '0.3.3'
 
 source git: 'https://github.com/openflighthpc/flight-metal'
 

--- a/builders/flight-metal/omnibus.rb
+++ b/builders/flight-metal/omnibus.rb
@@ -39,7 +39,7 @@
 #
 # Uncomment this line to change the default base directory to "local"
 # -------------------------------------------------------------------
-base_dir './local'
+base_dir '/home/vagrant/flight-metal/local'
 #
 # Alternatively you can tune the individual values
 # ------------------------------------------------

--- a/builders/flight-runway/.bundle/config
+++ b/builders/flight-runway/.bundle/config
@@ -1,0 +1,3 @@
+---
+BUNDLE_PATH: "/home/vagrant/flight-runway/vendor"
+BUNDLE_BIN: "bin"

--- a/builders/flight-runway/.gitignore
+++ b/builders/flight-runway/.gitignore
@@ -1,5 +1,4 @@
 *.gem
-.bundle
 .kitchen/
 .kitchen.local.yml
 pkg/*

--- a/builders/flight-runway/omnibus.rb
+++ b/builders/flight-runway/omnibus.rb
@@ -39,7 +39,7 @@
 #
 # Uncomment this line to change the default base directory to "local"
 # -------------------------------------------------------------------
-base_dir './local'
+base_dir '/home/vagrant/flight-runway/local'
 #
 # Alternatively you can tune the individual values
 # ------------------------------------------------

--- a/builders/openflight-tools/.bundle/config
+++ b/builders/openflight-tools/.bundle/config
@@ -1,0 +1,3 @@
+---
+BUNDLE_PATH: "/home/vagrant/openflight-tools/vendor"
+BUNDLE_BIN: "bin"

--- a/builders/openflight-tools/.gitignore
+++ b/builders/openflight-tools/.gitignore
@@ -1,5 +1,4 @@
 *.gem
-.bundle
 .kitchen/
 .kitchen.local.yml
 pkg/*

--- a/builders/openflight-tools/omnibus.rb
+++ b/builders/openflight-tools/omnibus.rb
@@ -39,7 +39,7 @@
 #
 # Uncomment this line to change the default base directory to "local"
 # -------------------------------------------------------------------
-base_dir './local'
+base_dir '/home/vagrant/openflight-tools/local'
 #
 # Alternatively you can tune the individual values
 # ------------------------------------------------


### PR DESCRIPTION
From investigation it seems that the build issues that could appear when installing the ffi gem are not in fact caused by the source box image, version of VirtualBox, vagrant version or any number of configuration issues and, instead, seem to be related to the vboxsf filesystem mount of the omnibus repo to `/vagrant`.

The problem appears to be that an unclean shutdown of the VM will cause the mount to behave strangely and get many io errors when subsequently trying to do lots of write operations over the mount.

To address this, and improve the performance of RPM creation, both gems and the local build files for a package will be created in `/home/vagrant/flight-example` on the VM's local disk. This has been somewhat tested and seems to behave a lot better than using the mounted directory.