### PR TITLE
Add arm support

### DIFF
--- a/builders/openflighthpc-release/openflighthpc-release.spec
+++ b/builders/openflighthpc-release/openflighthpc-release.spec
@@ -13,7 +13,7 @@ Source0:        https://raw.githubusercontent.com/openflighthpc/openflight-omnib
 Source1:        https://openflighthpc.s3-eu-west-1.amazonaws.com/repos/openflight/openflight.repo
 %define SHA256SUM1 eef326f52cb3899837136753c3380602f9594c8e35be1d593c148be2021b3572
 Source2:        https://openflighthpc.s3-eu-west-1.amazonaws.com/repos/openflight-dev/openflight-dev.repo
-%define SHA256SUM2 3caca02c70445670432de4e09108824e6dc98cd775d23c80a30be6b531d6ec67
+%define SHA256SUM2 06f83e15a4bff7eba52c50c35133af3955b2d765b021316ade9b1541d843e2c9
 #Source3:        https://openflighthpc.org/RPM-GPG-KEY-OPENFLIGHT
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)

--- a/scripts/promote-rpms.sh
+++ b/scripts/promote-rpms.sh
@@ -82,12 +82,11 @@ aws --region "${REGION}" s3 sync "s3://${TARGET_PREFIX}" $TARGET_DIR
 
 # copy the RPM in and update the repo
 NOARCH_TARGETS="x86_64 aarch64"
-mkdir -pv $TARGET_DIR/{${NOARCH_TARGETS/ /,}}/
+bash -c "mkdir -pv $TARGET_DIR/{${NOARCH_TARGETS/ /,}}/"
 shopt -s nullglob
 
 # Locate RPM
 matches="$(find $SOURCE_DIR -path "*$RPM_MATCH*")"
-targets="$(echo $SOURCE_DIR/{${NOARCH_TARGETS/ /,}}/${RPM_MATCH}.{noarch,x86_64,aarch64}.rpm*)"
 echo matches: $matches
 shopt -u nullglob
 

--- a/scripts/promote-rpms.sh
+++ b/scripts/promote-rpms.sh
@@ -87,7 +87,6 @@ shopt -s nullglob
 
 # Locate RPM
 matches="$(find $SOURCE_DIR -path "*$RPM_MATCH*")"
-echo matches: $matches
 shopt -u nullglob
 
 # Exit if no matches found
@@ -105,6 +104,8 @@ if [[ $(echo "$matches" |wc -l) -gt 1 ]] ; then
     echo "    aarch64/flight-starter-banner-1.2.1-1.noarch.rpm"
     exit 1
 fi
+
+echo "Match: $matches"
 
 ARCH="$(rpm -qip $matches |grep '^Architecture' |awk '{print $2}')"
 

--- a/scripts/promote-rpms.sh
+++ b/scripts/promote-rpms.sh
@@ -81,22 +81,52 @@ mkdir -p $TARGET_DIR
 aws --region "${REGION}" s3 sync "s3://${TARGET_PREFIX}" $TARGET_DIR
 
 # copy the RPM in and update the repo
-mkdir -pv $TARGET_DIR/{x86_64,aarch64}/
+NOARCH_TARGETS="x86_64 aarch64"
+mkdir -pv $TARGET_DIR/{${NOARCH_TARGETS/ /,}}/
 shopt -s nullglob
-targets="$(echo $SOURCE_DIR/{x86_64,aarch64}/${RPM_MATCH}.{noarch,x86_64,aarch64}.rpm*)"
-echo targets: $targets
+
+# Locate RPM
+matches="$(find $SOURCE_DIR -path "*$RPM_MATCH*")"
+targets="$(echo $SOURCE_DIR/{${NOARCH_TARGETS/ /,}}/${RPM_MATCH}.{noarch,x86_64,aarch64}.rpm*)"
+echo matches: $matches
 shopt -u nullglob
-if [ -z "$targets" ]; then
-  echo "No match found: $SOURCE_DIR/{x86_64,aarch64}/${RPM_MATCH}.{noarch,x86_64,aarch64}.rpm"
+
+# Exit if no matches found
+if [ -z "$matches" ]; then
+  echo "No match found: $SOURCE_DIR/{${NOARCH_TARGETS/ /,}}/${RPM_MATCH}*"
   exit 1
 fi
-ARCH="$(rpm -qip $targets |grep '^Architecture' |awk '{print $2}')"
-cp -rv ${targets} $TARGET_DIR/$ARCH/
-UPDATE=""
-if [ -e "${TARGET_DIR}/noarch/repodata/repomd.xml" ]; then
-  UPDATE="--update "
+
+# Exit if more than one match found
+if [[ $(echo "$matches" |wc -l) -gt 1 ]] ; then
+    echo "More than one match found: "
+    echo "$matches"
+    echo
+    echo "Please refine the argument to match more specifically, this can be done by ensuring that version number, build date, architecture and parent directory are included in the argument:"
+    echo "    aarch64/flight-starter-banner-1.2.1-1.noarch.rpm"
+    exit 1
 fi
-createrepo -v $UPDATE --deltas $TARGET_DIR/$ARCH/
+
+ARCH="$(rpm -qip $matches |grep '^Architecture' |awk '{print $2}')"
+
+# Push to all architectures if noarch rpm
+if [ "$ARCH" == "noarch" ] ; then
+    for arch in $NOARCH_TARGETS ; do 
+        cp -rv ${matches} $TARGET_DIR/$arch/
+        UPDATE=""
+        if [ -e "${TARGET_DIR}/$arch/repodata/repomd.xml" ]; then
+          UPDATE="--update "
+        fi
+        createrepo -v $UPDATE --deltas $TARGET_DIR/$arch/
+    done
+else
+    cp -rv ${matches} $TARGET_DIR/$ARCH/
+    UPDATE=""
+    if [ -e "${TARGET_DIR}/$ARCH/repodata/repomd.xml" ]; then
+      UPDATE="--update "
+    fi
+    createrepo -v $UPDATE --deltas $TARGET_DIR/$ARCH/
+fi
 
 # sync the repo state back to s3
 aws --region "${REGION}" s3 sync $TARGET_DIR s3://$TARGET_PREFIX

--- a/scripts/publish-rpm.sh
+++ b/scripts/publish-rpm.sh
@@ -48,6 +48,7 @@ fi
 
 RPM="$1"
 SOURCE_DIR=$(mktemp -d /tmp/publish-rpm.XXXXXX)
+ARCH="$(rpm -qip $RPM |grep '^Architecture' |awk '{print $2}')"
 cp $RPM $SOURCE_DIR
-$SCRIPT_DIR/publish-rpms.sh -s "$SOURCE_DIR" -t "openflighthpc/repos/openflight-dev"
+$SCRIPT_DIR/publish-rpms.sh -s "$SOURCE_DIR" -t "openflighthpc/repos/openflight-dev" -a "$ARCH"
 rm -rf $SOURCE_DIR

--- a/scripts/publish-rpms.sh
+++ b/scripts/publish-rpms.sh
@@ -42,7 +42,7 @@ do
   fi
 done
 
-while getopts "s:t:" opt; do
+while getopts "s:t:a:" opt; do
   case $opt in
     s) SOURCE_DIR=$OPTARG ;;
     t) TARGET_PREFIX=$OPTARG ;;

--- a/scripts/publish-rpms.sh
+++ b/scripts/publish-rpms.sh
@@ -46,6 +46,7 @@ while getopts "s:t:" opt; do
   case $opt in
     s) SOURCE_DIR=$OPTARG ;;
     t) TARGET_PREFIX=$OPTARG ;;
+    a) ARCH=$OPTARG ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
       exit 1
@@ -70,14 +71,14 @@ mkdir -p $TARGET_DIR
 aws --region "${REGION}" s3 sync "s3://${TARGET_PREFIX}" $TARGET_DIR
 
 # copy the RPM in and update the repo
-mkdir -pv $TARGET_DIR/x86_64/
-cp -rv $SOURCE_DIR/*.rpm $TARGET_DIR/x86_64/
+mkdir -pv $TARGET_DIR/$ARCH/
+cp -rv $SOURCE_DIR/*.rpm $TARGET_DIR/$ARCH/
 UPDATE=""
-if [ -e "$TARGET_DIR/x86_64/repodata/repomd.xml" ]; then
+if [ -e "$TARGET_DIR/$ARCH/repodata/repomd.xml" ]; then
   UPDATE="--update "
 fi
 
-createrepo -v $UPDATE --deltas $TARGET_DIR/x86_64/
+createrepo -v $UPDATE --deltas $TARGET_DIR/$ARCH/
 
 # sync the repo state back to s3
 aws --region "${REGION}" s3 sync $TARGET_DIR s3://$TARGET_PREFIX

--- a/scripts/publish-rpms.sh
+++ b/scripts/publish-rpms.sh
@@ -71,14 +71,27 @@ mkdir -p $TARGET_DIR
 aws --region "${REGION}" s3 sync "s3://${TARGET_PREFIX}" $TARGET_DIR
 
 # copy the RPM in and update the repo
-mkdir -pv $TARGET_DIR/$ARCH/
-cp -rv $SOURCE_DIR/*.rpm $TARGET_DIR/$ARCH/
-UPDATE=""
-if [ -e "$TARGET_DIR/$ARCH/repodata/repomd.xml" ]; then
-  UPDATE="--update "
-fi
+NOARCH_TARGETS="x86_64 aarch64"
 
-createrepo -v $UPDATE --deltas $TARGET_DIR/$ARCH/
+if [ "$ARCH" == "noarch" ] ; then
+    for arch in $NOARCH_TARGETS ; do
+        mkdir -pv $TARGET_DIR/$arch
+        cp -rv $SOURCE_DIR/*.rpm $TARGET_DIR/$arch
+        UPDATE=""
+        if [ -e "$TARGET_DIR/$arch/repodata/repomd.xml" ]; then
+          UPDATE="--update "
+        fi
+        createrepo -v $UPDATE --deltas $TARGET_DIR/$arch/
+    done
+else
+    mkdir -pv $TARGET_DIR/$ARCH/
+    cp -rv $SOURCE_DIR/*.rpm $TARGET_DIR/$ARCH/
+    UPDATE=""
+    if [ -e "$TARGET_DIR/$ARCH/repodata/repomd.xml" ]; then
+      UPDATE="--update "
+    fi
+    createrepo -v $UPDATE --deltas $TARGET_DIR/$ARCH/
+fi
 
 # sync the repo state back to s3
 aws --region "${REGION}" s3 sync $TARGET_DIR s3://$TARGET_PREFIX


### PR DESCRIPTION
**This PR is for a WIP branch and should not yet be merged until fully tested and verified to be working**

Currently the omnibus publish & promote scripts for RPMs are hard-coded for x86_64. This PR aims to introduce complete architecture flexibility by utilising the RPM command to identify the architecture of built packages and to upload them to the correct locations.

The above should allow for the openflight repo to support multiple architectures.