### PR TITLE
Use flight service to configure desktop client

### DIFF
--- a/builders/flight-desktop-client/config/projects/flight-desktop-client.rb
+++ b/builders/flight-desktop-client/config/projects/flight-desktop-client.rb
@@ -48,8 +48,7 @@ exclude '**/.gitkeep'
 exclude '**/bundler/git'
 exclude 'node_modules'
 
-runtime_dependency 'flight-runway'
-runtime_dependency 'flight-desktop-server'
+runtime_dependency 'flight-service => 1.0.0'
 
 require 'find'
 Find.find('opt') do |o|

--- a/builders/flight-desktop-client/opt/flight/etc/service/desktop-client/configuration.yml
+++ b/builders/flight-desktop-client/opt/flight/etc/service/desktop-client/configuration.yml
@@ -6,7 +6,7 @@ text: |
   Cluster name: The human-friendly name of the cluster.
   Cluster description: A human-friendly description of the cluster.  This could be used to describe its purpose or the features that it supports.
   Cluster logo: The URL of a logo for the cluster.  Leave blank to not use a logo.
-  Hostname or IP: The hostname of IP address for this cluster.
+  Hostname or IP: The hostname or IP address for this cluster.
 
 values:
   - key: clusterName

--- a/builders/flight-desktop-client/opt/flight/etc/service/desktop-client/configuration.yml
+++ b/builders/flight-desktop-client/opt/flight/etc/service/desktop-client/configuration.yml
@@ -1,0 +1,30 @@
+---
+title: "Flight desktop access service client"
+text: |
+  Please provide values for the following configuration items.
+
+  Cluster name: The human-friendly name of the cluster.
+  Cluster description: A human-friendly description of the cluster.  This could be used to describe its purpose or the features that it supports.
+  Cluster logo: The URL of a logo for the cluster.  Leave blank to not use a logo.
+  Hostname or IP: The hostname of IP address for this cluster.
+
+values:
+  - key: clusterName
+    label: Cluster name
+    value: ''
+    length: 32
+
+  - key: clusterDescription
+    label: Cluster description
+    value: ''
+    length: 512
+
+  - key: clusterLogo
+    label: Cluster logo
+    value: ''
+    length: 512
+
+  - key: hostname
+    label: Hostname or IP
+    value: ''
+    length: 128

--- a/builders/flight-desktop-client/opt/flight/etc/service/desktop-client/configure.sh
+++ b/builders/flight-desktop-client/opt/flight/etc/service/desktop-client/configure.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+echo "Configuring"
+
+set_string() {
+    local key
+    local value
+    key="$1"
+    value=$( echo "${2}" | sed -s 's/"/\\"/g' )
+
+    # NOTE: This script is practically identical to `set_nil`.  If changing
+    # one, change the other.
+  "${flight_ROOT}/bin/ruby" <<EOF
+require 'json'
+json = File.read('/opt/flight/opt/flight-desktop-client/build/config.json')
+config = JSON.parse(json)
+config["${key}"] = "${value}"
+new_json = JSON.pretty_generate(config)
+File.write('/opt/flight/opt/flight-desktop-client/build/config.json', new_json)
+EOF
+}
+
+set_nil() {
+    local key
+    key="$1"
+
+
+    # NOTE: This script is practically identical to `set_string`.  If changing
+    # one, change the other.
+  "${flight_ROOT}/bin/ruby" <<EOF
+require 'json'
+json = File.read('/opt/flight/opt/flight-desktop-client/build/config.json')
+config = JSON.parse(json)
+config["${key}"] = nil
+new_json = JSON.pretty_generate(config)
+File.write('/opt/flight/opt/flight-desktop-client/build/config.json', new_json)
+EOF
+}
+
+for a in "$@"; do
+  IFS="=" read k v <<< "${a}"
+  case $k in
+    clusterName)
+      set_string clusterName "${v}"
+      ;;
+
+    clusterDescription)
+      set_string clusterDescription "${v}"
+      ;;
+
+    clusterLogo)
+      if [[ -z "${v// }" ]]; then
+          set_nil clusterLogo
+      else
+          set_string clusterLogo "${v}"
+      fi
+      ;;
+
+    hostname)
+      url="https://${v}/desktop/api"
+      set_string apiRootUrl "${url}"
+      ;;
+    *)
+      echo "Unrecognised key: $k"
+    ;;
+  esac
+done

--- a/builders/flight-desktop-client/opt/flight/etc/service/desktop-client/metadata.yml
+++ b/builders/flight-desktop-client/opt/flight/etc/service/desktop-client/metadata.yml
@@ -1,0 +1,2 @@
+:name: desktop-client
+:summary: Flight Desktop Access service client

--- a/builders/flight-desktop-client/package-scripts/flight-desktop-client/postinst
+++ b/builders/flight-desktop-client/package-scripts/flight-desktop-client/postinst
@@ -26,7 +26,10 @@
 # https://github.com/openflighthpc/openflight-omnibus-builder
 #===============================================================================
 cat <<EOF 1>&2
-flight-desktop-client can be configured by editing /opt/flight/opt/flight-desktop-client/build/config.json.
+flight-desktop-client should now be configured by running 
+
+  /opt/flight/bin/flight service configure desktop-client
+
 EOF
 
 exit 0

--- a/builders/flight-service/config/projects/flight-service.rb
+++ b/builders/flight-service/config/projects/flight-service.rb
@@ -31,7 +31,7 @@ friendly_name 'Manage HPC environment services'
 
 install_dir '/opt/flight/opt/service'
 
-build_version '0.1.2'
+build_version '1.0.0'
 build_iteration 1
 
 dependency 'preparation'

--- a/builders/flight-service/config/software/flight-service.rb
+++ b/builders/flight-service/config/software/flight-service.rb
@@ -25,7 +25,7 @@
 # https://github.com/openflighthpc/openflight-omnibus-builder
 #===============================================================================
 name 'flight-service'
-default_version '0.1.2'
+default_version '1.0.0'
 
 source git: 'https://github.com/openflighthpc/flight-service'
 


### PR DESCRIPTION
Use `flight service configure` to configure `flight-desktop-client`.  The `configuration.yml` file assumes a version of `flight-service` including https://github.com/openflighthpc/flight-service/pull/4.