### PR TITLE
Script to setup HTTPs for flight-service-www

### DIFF
--- a/builders/flight-service-www/opt/flight/bin/flight-service-www-https
+++ b/builders/flight-service-www/opt/flight/bin/flight-service-www-https
@@ -1,0 +1,106 @@
+#!/bin/bash
+set -e
+
+assert_user_is_root() {
+    if [[ "$( id -u )" != "0" ]] ; then
+        echo "Must be root to run this script" >&2
+        exit 1
+    fi
+}
+
+format() {
+    local columns=${COLUMNS:-`tput cols 2>&-||echo 80`}
+    if [ type fmt 1>/dev/null 2>/dev/null ] ; then
+        echo -e "$@" | fmt -w ${columns}
+    else
+        echo -e "$@"
+    fi
+}
+
+create_certs() {
+    format "To enable HTTPs SSL certificates need to be generated.  We will" \
+        "step you through generating self-signed certificates that are" \
+        "valid for 1 year.\n"
+    format "You will be asked to enter a passphrase and to provide details" \
+        "about your organization.\n"
+    format "When you are ready press enter to continue or Ctrl-C to abort.\n"
+
+    read -s
+
+    mkdir -p /root/flight/www/certs
+    cd /root/flight/www/certs
+    openssl req -new > cert.csr
+
+    format "\nWe will now generate a public key.  You will be asked to enter" \
+        "the passphrase you provided earlier.\n"
+    format "When you are ready press enter to continue or Ctrl-C to abort.\n"
+    read -s
+
+    openssl rsa -in privkey.pem -out key.pem
+    openssl x509 -in cert.csr -out cert.pem -req -signkey key.pem -days 365
+    cat key.pem >> cert.pem
+    cd - 1>/dev/null
+}
+
+
+install_certs() {
+    mkdir -p "${flight_ROOT}"/etc/www/ssl
+    cp /root/flight/www/certs/cert.pem "${flight_ROOT}"/etc/www/ssl/fullchain.pem
+    cp /root/flight/www/certs/key.pem "${flight_ROOT}"/etc/www/ssl/key.pem
+}
+
+reload_www_service() {
+    "${flight_ROOT}"/bin/flight service stop www || true
+    sleep 1
+    "${flight_ROOT}"/bin/flight service start www || true
+}
+
+enable_https() {
+    create_certs
+    install_certs
+    mv "${flight_ROOT}"/etc/www/http.d/https.conf{.disabled,}
+    reload_www_service
+}
+
+disable_https() {
+    mv "${flight_ROOT}"/etc/www/http.d/https.conf{,.disabled}
+    reload_www_service
+}
+
+usage() {
+    local prog
+    prog=$(basename "$0")
+    echo "Usage: ${prog} enable|disable"
+    echo "Enable or disable HTTPs support for the flight www service."
+}
+
+main() {
+    assert_user_is_root
+
+    case "$1" in
+        enable)
+            shift
+            enable_https "${@}"
+            ;;
+
+        disable)
+            shift
+            disable_https "${@}"
+            ;;
+
+        --help | help)
+            usage
+            exit 0
+            ;;
+
+        *)
+            usage
+            exit 2
+            ;;
+    esac
+}
+
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/builders/flight-service-www/opt/flight/bin/flight-service-www-https
+++ b/builders/flight-service-www/opt/flight/bin/flight-service-www-https
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+CERT_DIR="/root/flight/www/certs"
+
 assert_user_is_root() {
     if [[ "$( id -u )" != "0" ]] ; then
         echo "Must be root to run this script" >&2
@@ -17,36 +19,44 @@ format() {
     fi
 }
 
+create_private_key() {
+    if [ -f "${CERT_DIR}"/cert.csr -a -f "${CERT_DIR}"/privkey.pem ] ; then
+        echo "Using existing private key."
+    else
+        format "To enable HTTPs SSL certificates need to be generated.  We will" \
+            "step you through generating self-signed certificates that are" \
+            "valid for 1 year.\n"
+        format "You will be asked to enter a passphrase and to provide details" \
+            "about your organization.\n"
+        format "When you are ready press enter to continue or Ctrl-C to abort.\n"
+
+        read -s
+
+        mkdir -p "${CERT_DIR}"
+        openssl req -new > "${CERT_DIR}"/cert.csr
+    fi
+}
+
 create_certs() {
-    format "To enable HTTPs SSL certificates need to be generated.  We will" \
-        "step you through generating self-signed certificates that are" \
-        "valid for 1 year.\n"
-    format "You will be asked to enter a passphrase and to provide details" \
-        "about your organization.\n"
-    format "When you are ready press enter to continue or Ctrl-C to abort.\n"
-
-    read -s
-
-    mkdir -p /root/flight/www/certs
-    cd /root/flight/www/certs
-    openssl req -new > cert.csr
-
     format "\nWe will now generate a public key.  You will be asked to enter" \
         "the passphrase you provided earlier.\n"
     format "When you are ready press enter to continue or Ctrl-C to abort.\n"
     read -s
 
-    openssl rsa -in privkey.pem -out key.pem
-    openssl x509 -in cert.csr -out cert.pem -req -signkey key.pem -days 365
-    cat key.pem >> cert.pem
-    cd - 1>/dev/null
+    openssl rsa -in "${CERT_DIR}"/privkey.pem -out "${CERT_DIR}"/key.pem
+    openssl x509 -in "${CERT_DIR}"/cert.csr \
+        -out "${CERT_DIR}"/cert.pem \
+        -req \
+        -signkey "${CERT_DIR}"/key.pem \
+        -days 365
+    cat "${CERT_DIR}"/key.pem >> "${CERT_DIR}"/cert.pem
 }
 
 
 install_certs() {
     mkdir -p "${flight_ROOT}"/etc/www/ssl
-    cp /root/flight/www/certs/cert.pem "${flight_ROOT}"/etc/www/ssl/fullchain.pem
-    cp /root/flight/www/certs/key.pem "${flight_ROOT}"/etc/www/ssl/key.pem
+    cp "${CERT_DIR}"/cert.pem "${flight_ROOT}"/etc/www/ssl/fullchain.pem
+    cp "${CERT_DIR}"/key.pem "${flight_ROOT}"/etc/www/ssl/key.pem
 }
 
 reload_www_service() {
@@ -56,6 +66,7 @@ reload_www_service() {
 }
 
 enable_https() {
+    create_private_key
     create_certs
     install_certs
     mv "${flight_ROOT}"/etc/www/http.d/https.conf{.disabled,}

--- a/builders/flight-service-www/opt/flight/libexec/commands/www
+++ b/builders/flight-service-www/opt/flight/libexec/commands/www
@@ -1,0 +1,37 @@
+: '
+: NAME: www
+: SYNOPSIS: Flight environment web server
+: VERSION: 0.1.0
+: ROOT: true
+: '
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of Flight Service.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Service is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Service. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Service, please visit:
+# https://github.com/alces-flight/flight-service
+# ==============================================================================
+if [ "$UID" != 0 ]; then
+  exec sudo "${flight_ROOT}"/bin/flight "$(basename "$0")" "$@"
+fi
+
+"${flight_ROOT}"/opt/www/bin/https "$@"

--- a/builders/flight-service-www/opt/flight/opt/www/bin/https
+++ b/builders/flight-service-www/opt/flight/opt/www/bin/https
@@ -48,7 +48,7 @@ create_certs() {
         -out "${CERT_DIR}"/cert.pem \
         -req \
         -signkey "${CERT_DIR}"/key.pem \
-        -days 365
+        -days 3650
     cat "${CERT_DIR}"/key.pem >> "${CERT_DIR}"/cert.pem
 }
 

--- a/builders/flight-service-www/opt/flight/opt/www/bin/https
+++ b/builders/flight-service-www/opt/flight/opt/www/bin/https
@@ -80,8 +80,8 @@ disable_https() {
 
 usage() {
     local prog
-    prog=$(basename "$0")
-    echo "Usage: ${prog} enable|disable"
+    prog="flight www"
+    echo "Usage: ${prog} enable-https|disable-https"
     echo "Enable or disable HTTPs support for the flight www service."
 }
 
@@ -89,12 +89,12 @@ main() {
     assert_user_is_root
 
     case "$1" in
-        enable)
+        enable-https)
             shift
             enable_https "${@}"
             ;;
 
-        disable)
+        disable-https)
             shift
             disable_https "${@}"
             ;;

--- a/builders/flight-service-www/opt/flight/opt/www/bin/https
+++ b/builders/flight-service-www/opt/flight/opt/www/bin/https
@@ -1,7 +1,11 @@
 #!/bin/bash
 set -e
 
-CERT_DIR="/root/flight/www/certs"
+CERT_DIR=$(mktemp -d /tmp/flight-www-certs.XXXXXX)
+clean_up() {
+  rm -rf "${CERT_DIR}"
+}
+ trap clean_up EXIT
 
 assert_user_is_root() {
     if [[ "$( id -u )" != "0" ]] ; then
@@ -20,21 +24,19 @@ format() {
 }
 
 create_private_key() {
-    if [ -f "${CERT_DIR}"/cert.csr -a -f "${CERT_DIR}"/privkey.pem ] ; then
-        echo "Using existing private key."
-    else
-        format "To enable HTTPs SSL certificates need to be generated.  We will" \
-            "step you through generating self-signed certificates that are" \
-            "valid for 10 years.\n"
-        format "You will be asked to enter a passphrase and to provide details" \
-            "about your organization.\n"
-        format "When you are ready press enter to continue or Ctrl-C to abort.\n"
+    format "To enable HTTPs SSL certificates need to be generated.  We will" \
+        "step you through generating self-signed certificates that are" \
+        "valid for 10 years.\n"
+    format "You will be asked to enter a passphrase and to provide details" \
+        "about your organization.\n"
+    format "When you are ready press enter to continue or Ctrl-C to abort.\n"
 
-        read -s
+    read -s
 
-        mkdir -p "${CERT_DIR}"
-        openssl req -new > "${CERT_DIR}"/cert.csr
-    fi
+    mkdir -p "${CERT_DIR}"
+    cd "${CERT_DIR}"
+    openssl req -new > "${CERT_DIR}"/cert.csr
+    cd - 1>/dev/null
 }
 
 create_certs() {
@@ -60,12 +62,11 @@ install_certs() {
 }
 
 reload_www_service() {
-    "${flight_ROOT}"/bin/flight service stop www || true
-    sleep 1
-    "${flight_ROOT}"/bin/flight service start www || true
+    "${flight_ROOT}"/bin/flight service restart www || true
 }
 
 enable_https() {
+    echo "CERT_DIR=${CERT_DIR}"
     create_private_key
     create_certs
     install_certs

--- a/builders/flight-service-www/opt/flight/opt/www/bin/https
+++ b/builders/flight-service-www/opt/flight/opt/www/bin/https
@@ -25,7 +25,7 @@ create_private_key() {
     else
         format "To enable HTTPs SSL certificates need to be generated.  We will" \
             "step you through generating self-signed certificates that are" \
-            "valid for 1 year.\n"
+            "valid for 10 years.\n"
         format "You will be asked to enter a passphrase and to provide details" \
             "about your organization.\n"
         format "When you are ready press enter to continue or Ctrl-C to abort.\n"


### PR DESCRIPTION
This PR adds a script to setup HTTPs for `flight-service-www`.  It 1) generates self-signed SSL certificates; 2) copies them to the correct location; 3) configures nginx to use HTTPs; and 4) restarts the `www` service.

The script is added to `/opt/flight/bin/` and is expected to be called as `flexec flight-service-www-https enable`.

I have a couple of questions regarding this:

 1. Is the `/opt/flight/bin/` the correct location for this script?  Or should it be somewhere in `/opt/flight/libexec/`?

 2. The certificate is valid for 365 days.  Do you have any reason that this should be different?