### PR TITLE
Add upper dependency bounds to flight-desktop-*

### DIFF
--- a/builders/flight-desktop-restapi/config/projects/flight-desktop-restapi.rb
+++ b/builders/flight-desktop-restapi/config/projects/flight-desktop-restapi.rb
@@ -62,10 +62,24 @@ exclude '**/.git'
 exclude '**/.gitkeep'
 exclude '**/bundler/git'
 
-runtime_dependency "flight-runway"
-# NOTE: This syntax matches the RPM version syntax and may need tweaking for other distros
-runtime_dependency "flight-desktop >= #{CLI_VERSION}, flight-desktop < #{MAX_CLI_VERSION}"
+runtime_dep_versions = {
+  'flight-desktop': {
+                     gte: CLI_VERSION,
+                     lt: MAX_CLI_VERSION,
+                   },
+  'flight-runway': {
+                     gte: '1.1.0',
+                     lt: '1.2.0',
+                   }
+}
+
 runtime_dependency 'flight-service-www'
+
+# NOTE: This syntax matches the RPM version syntax and may need tweaking for
+# other distros.
+runtime_dep_versions.each do |k,v|
+  runtime_dependency "#{k} >= #{v[:gte]}, #{k} < #{v[:lt]}"
+end
 
 require 'find'
 Find.find('opt') do |o|

--- a/builders/flight-desktop-webapp/config/projects/flight-desktop-webapp.rb
+++ b/builders/flight-desktop-webapp/config/projects/flight-desktop-webapp.rb
@@ -48,7 +48,17 @@ exclude '**/.gitkeep'
 exclude '**/bundler/git'
 exclude 'node_modules'
 
-runtime_dependency 'flight-service => 1.0.0'
+runtime_dep_versions = {
+  'flight-service': {
+                     gte: '1.0.0',
+                     lt: '1.1.0',
+                   }
+}
+
+runtime_dep_versions.each do |k,v|
+  runtime_dependency "#{k} >= #{v[:gte]}, #{k} < #{v[:lt]}"
+end
+
 runtime_dependency 'flight-service-www'
 
 require 'find'


### PR DESCRIPTION
This PR adds upper bounds to the dependencies of `flight-desktop-restapi` and `flight-desktop-webapp`.

@ColonelPanicks / @mjtko I didn't want to commit these changes to master whilst #21 is still a WIP.  Let me know if you want me to do so.