### PR TITLE
Flight console configure page

### DIFF
--- a/builders/flight-console-webapp/config/projects/flight-console-webapp.rb
+++ b/builders/flight-console-webapp/config/projects/flight-console-webapp.rb
@@ -31,7 +31,7 @@ friendly_name 'Flight Console Webapp'
 
 install_dir '/opt/flight/opt/console-webapp'
 
-VERSION = '0.0.4'
+VERSION = '0.0.5'
 override 'flight-console-webapp', version: VERSION
 
 build_version VERSION

--- a/builders/flight-console-webapp/config/projects/flight-console-webapp.rb
+++ b/builders/flight-console-webapp/config/projects/flight-console-webapp.rb
@@ -31,11 +31,11 @@ friendly_name 'Flight Console Webapp'
 
 install_dir '/opt/flight/opt/console-webapp'
 
-VERSION = '0.0.2'
+VERSION = '0.0.3'
 override 'flight-console-webapp', version: VERSION
 
 build_version VERSION
-build_iteration 3
+build_iteration 0
 
 dependency 'preparation'
 dependency 'flight-console-webapp'

--- a/builders/flight-console-webapp/config/projects/flight-console-webapp.rb
+++ b/builders/flight-console-webapp/config/projects/flight-console-webapp.rb
@@ -31,7 +31,7 @@ friendly_name 'Flight Console Webapp'
 
 install_dir '/opt/flight/opt/console-webapp'
 
-VERSION = '0.0.3'
+VERSION = '0.0.4'
 override 'flight-console-webapp', version: VERSION
 
 build_version VERSION

--- a/builders/flight-console-webapp/opt/flight/etc/service/types/console-webapp/configure.sh
+++ b/builders/flight-console-webapp/opt/flight/etc/service/types/console-webapp/configure.sh
@@ -11,8 +11,12 @@ set_string() {
     # one, change the other.
   "${flight_ROOT}/bin/ruby" <<EOF
 require 'json'
-json = File.read('/opt/flight/opt/console-webapp/build/config.json')
-config = JSON.parse(json)
+if File.exist?('/opt/flight/opt/console-webapp/build/config.json')
+  json = File.read('/opt/flight/opt/console-webapp/build/config.json')
+  config = JSON.parse(json)
+else
+  config = {}
+end
 config["${key}"] = "${value}"
 new_json = JSON.pretty_generate(config)
 File.write('/opt/flight/opt/console-webapp/build/config.json', new_json)
@@ -28,8 +32,12 @@ set_nil() {
     # one, change the other.
   "${flight_ROOT}/bin/ruby" <<EOF
 require 'json'
-json = File.read('/opt/flight/opt/console-webapp/build/config.json')
-config = JSON.parse(json)
+if File.exist?('/opt/flight/opt/console-webapp/build/config.json')
+  json = File.read('/opt/flight/opt/console-webapp/build/config.json')
+  config = JSON.parse(json)
+else
+  config = {}
+end
 config["${key}"] = nil
 new_json = JSON.pretty_generate(config)
 File.write('/opt/flight/opt/console-webapp/build/config.json', new_json)

--- a/builders/flight-console-webapp/opt/flight/etc/www/server-https.d/console-02-webapp.conf
+++ b/builders/flight-console-webapp/opt/flight/etc/www/server-https.d/console-02-webapp.conf
@@ -25,6 +25,11 @@
 # https://github.com/openflighthpc/openflight-omnibus-builder
 #===============================================================================
 
+location ~ ^/console/config(.*)$ {
+    root /opt/flight/opt/console-webapp/build/config;
+    try_files $1 =404;
+}
+
 location ~ ^/console(.*)$ {
     root /opt/flight/opt/console-webapp/build/;
     index index.html;

--- a/builders/flight-desktop-webapp/config/projects/flight-desktop-webapp.rb
+++ b/builders/flight-desktop-webapp/config/projects/flight-desktop-webapp.rb
@@ -31,7 +31,7 @@ friendly_name 'Flight Desktop Webapp'
 
 install_dir '/opt/flight/opt/desktop-webapp'
 
-VERSION = '1.2.0-rc2'
+VERSION = '1.2.0'
 override 'flight-desktop-webapp', version: VERSION
 
 build_version VERSION

--- a/builders/flight-desktop-webapp/config/projects/flight-desktop-webapp.rb
+++ b/builders/flight-desktop-webapp/config/projects/flight-desktop-webapp.rb
@@ -31,11 +31,11 @@ friendly_name 'Flight Desktop Webapp'
 
 install_dir '/opt/flight/opt/desktop-webapp'
 
-VERSION = '1.1.1'
+VERSION = '1.2.0-rc1'
 override 'flight-desktop-webapp', version: VERSION
 
 build_version VERSION
-build_iteration 2
+build_iteration 0
 
 dependency 'preparation'
 dependency 'flight-desktop-webapp'

--- a/builders/flight-desktop-webapp/config/projects/flight-desktop-webapp.rb
+++ b/builders/flight-desktop-webapp/config/projects/flight-desktop-webapp.rb
@@ -31,7 +31,7 @@ friendly_name 'Flight Desktop Webapp'
 
 install_dir '/opt/flight/opt/desktop-webapp'
 
-VERSION = '1.2.0-rc1'
+VERSION = '1.2.0-rc2'
 override 'flight-desktop-webapp', version: VERSION
 
 build_version VERSION

--- a/builders/flight-desktop-webapp/opt/flight/etc/service/types/desktop-webapp/configure.sh
+++ b/builders/flight-desktop-webapp/opt/flight/etc/service/types/desktop-webapp/configure.sh
@@ -11,8 +11,15 @@ set_string() {
     # one, change the other.
   "${flight_ROOT}/bin/ruby" <<EOF
 require 'json'
-json = File.read('/opt/flight/opt/desktop-webapp/build/config.json')
-config = JSON.parse(json)
+if File.exist?('/opt/flight/opt/desktop-webapp/build/config.json')
+  json = File.read('/opt/flight/opt/desktop-webapp/build/config.json')
+  config = JSON.parse(json)
+else
+  config = {
+    "websocketPathPrefix" => "/ws",
+    "websocketPathIp" => "127.0.0.1",
+  }
+end
 config["${key}"] = "${value}"
 new_json = JSON.pretty_generate(config)
 File.write('/opt/flight/opt/desktop-webapp/build/config.json', new_json)
@@ -28,8 +35,15 @@ set_nil() {
     # one, change the other.
   "${flight_ROOT}/bin/ruby" <<EOF
 require 'json'
-json = File.read('/opt/flight/opt/desktop-webapp/build/config.json')
-config = JSON.parse(json)
+if File.exist?('/opt/flight/opt/desktop-webapp/build/config.json')
+  json = File.read('/opt/flight/opt/desktop-webapp/build/config.json')
+  config = JSON.parse(json)
+else
+  config = {
+    "websocketPathPrefix" => "/ws",
+    "websocketPathIp" => "127.0.0.1",
+  }
+end
 config["${key}"] = nil
 new_json = JSON.pretty_generate(config)
 File.write('/opt/flight/opt/desktop-webapp/build/config.json', new_json)

--- a/builders/flight-desktop-webapp/opt/flight/etc/www/server-https.d/desktop-webapp.conf
+++ b/builders/flight-desktop-webapp/opt/flight/etc/www/server-https.d/desktop-webapp.conf
@@ -25,6 +25,11 @@
 # https://github.com/openflighthpc/openflight-omnibus-builder
 #===============================================================================
 
+location ~ ^/desktop/config(.*)$ {
+    root /opt/flight/opt/desktop-webapp/build/config;
+    try_files $1 =404;
+}
+
 location ~ ^/desktop(.*)$ {
     root /opt/flight/opt/desktop-webapp/build/;
     index index.html;

--- a/builders/flight-nodejs/config/software/flight-nodejs.rb
+++ b/builders/flight-nodejs/config/software/flight-nodejs.rb
@@ -39,6 +39,7 @@ end
 
 build do
   block do
+    FileUtils.mkdir_p '/opt/flight/bin'
     Dir.glob(File.join(File.dirname(__FILE__), '..', '..', 'dist', 'bin', '*')).each do |path|
       FileUtils.cp_r path, '/opt/flight/bin'
     end


### PR DESCRIPTION
This PR adds support for an "unconfigured" state to the console and desktop webapps.  If the webapps are unable to load their configuration, i.e., the request results in a 404, they are in an unconfigured state.  An unconfigured webapp displays a "configure me" dashboard.

Hoops are jumped through to ensure that they can be configured for the first time, and to ensure that a non-existent config does indeed result in a 404.

This PR also contains a fix for the nodejs builder.  The details of which are in the commit message of  https://github.com/openflighthpc/openflight-omnibus-builder/commit/546fb961faaf32b0d76ca7dab2269ddad9a463d3.  @mjtko I think the solution I've taken here is the right approach, its certainly the simplest.  Would you mind taking a quick look and confirming that there isn't something subtle that I'm missing.