### PR TITLE
Reinstate the flight-desktop-restapi restart.sh script

### DIFF
--- a/builders/flight-desktop-restapi/config/projects/flight-desktop-restapi.rb
+++ b/builders/flight-desktop-restapi/config/projects/flight-desktop-restapi.rb
@@ -31,7 +31,7 @@ friendly_name 'Flight Desktop REST API'
 
 install_dir '/opt/flight/opt/desktop-restapi'
 
-VERSION = '1.0.1'
+VERSION = '1.0.2'
 override 'flight-desktop-restapi', version: VERSION
 
 build_version VERSION

--- a/builders/flight-desktop-restapi/config/projects/flight-desktop-restapi.rb
+++ b/builders/flight-desktop-restapi/config/projects/flight-desktop-restapi.rb
@@ -35,7 +35,7 @@ VERSION = '1.0.2'
 override 'flight-desktop-restapi', version: VERSION
 
 build_version VERSION
-build_iteration 8
+build_iteration 1
 
 dependency 'preparation'
 dependency 'flight-desktop-restapi'

--- a/builders/flight-desktop-restapi/opt/flight/etc/service/types/desktop-restapi/restart.sh
+++ b/builders/flight-desktop-restapi/opt/flight/etc/service/types/desktop-restapi/restart.sh
@@ -29,7 +29,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 OLD_PID="$1"
 
-source "$DIR"/stop.sh "$OLD_PID"
+bash "$DIR"/stop.sh "$OLD_PID"
 
 # Wait up to 10ish seconds for puma to stop
 state=1
@@ -46,5 +46,4 @@ if [ "$state" -eq 0 ]; then
   exit 1
 fi
 
-source "$DIR"/start.sh
-
+bash "$DIR"/start.sh


### PR DESCRIPTION
The issue preventing the restart has been resolved by closing the file descriptor:
https://github.com/openflighthpc/flight-desktop-restapi/pull/40

The PR has been merged as I needed the tag to build off and it was relatively small. Apparently I fixed some but not all of the dependabot issues.