### PR TITLE
Remove the symlink to the share etc directory

### DIFF
--- a/builders/flight-www/config/projects/flight-www.rb
+++ b/builders/flight-www/config/projects/flight-www.rb
@@ -31,13 +31,13 @@ friendly_name 'Flight web server service'
 
 install_dir '/opt/flight/opt/www'
 
-VERSION = '1.2.1'
+VERSION = '1.2.2'
 CERT_VERSION = '0.2.1'
 override 'flight-www', version: VERSION
 override 'flight-cert', version: CERT_VERSION
 
 build_version VERSION
-build_iteration '2'
+build_iteration '1'
 
 dependency 'preparation'
 dependency 'flight-www'

--- a/builders/flight-www/config/projects/flight-www.rb
+++ b/builders/flight-www/config/projects/flight-www.rb
@@ -37,7 +37,7 @@ override 'flight-www', version: VERSION
 override 'flight-cert', version: CERT_VERSION
 
 build_version VERSION
-build_iteration '1'
+build_iteration '2'
 
 dependency 'preparation'
 dependency 'flight-www'

--- a/builders/flight-www/config/software/flight-cert.rb
+++ b/builders/flight-www/config/software/flight-cert.rb
@@ -51,9 +51,6 @@ build do
     ].each do |file|
       FileUtils.cp_r File.expand_path(file, project_dir), sub_install_dir
     end
-
-    # Links the internal config to the system version
-    FileUtils.ln_sf '/opt/flight/etc/share/cert.yaml', File.expand_path('etc/config.yaml', sub_install_dir)
   end
 
   # Installs the gems to the shared `vendor/share`

--- a/builders/flight-www/package-scripts/flight-www/postinst
+++ b/builders/flight-www/package-scripts/flight-www/postinst
@@ -36,4 +36,9 @@ fi
 
 /opt/flight/bin/flight landing-page compile
 
+# Move the deprecated shared config into the internal directory tree
+if [ -e /opt/flight/etc/share/cert.yaml ]; then
+  mv /opt/flight/etc/share/cert.yaml /opt/flight/opt/www/cert/etc/config.yaml
+fi
+
 exit 0


### PR DESCRIPTION
Whilst this would be a nice to have feature, it is
causing bugs in practice

A shared etc directory can be revisited if and when
there is a desire to get them in one place