### PR TITLE
Bump flight-user-suite

### DIFF
--- a/builders/flight-user-suite/build.sh
+++ b/builders/flight-user-suite/build.sh
@@ -4,8 +4,8 @@ d="$(pwd)"
 mkdir -p pkg
 
 NAME=flight-user-suite
-VERSION=2020.2
-REL=5
+VERSION=2020.3
+REL=1
 
 if [ -f /etc/redhat-release ]; then
   echo "Building RPM package..."

--- a/builders/flight-user-suite/deb/control.tpl
+++ b/builders/flight-user-suite/deb/control.tpl
@@ -5,4 +5,4 @@ Priority: optional
 Architecture: all
 Maintainer: OpenFlightHPC Project <flight@openflighthpc.org>
 Description: The Flight User Suite collection of HPC environment tools
-Depends: flight-runway (>= 1.1.0), flight-runway (<< 1.2.0), flight-starter (>= 2020.2.0), flight-starter (<< 2020.3.0), flight-env (>= 1.4.0), flight-env (<< 1.5.0), flight-desktop (>= 1.3.0), flight-desktop (<< 1.4.0)
+Depends: flight-runway (>= 1.1.0), flight-runway (<< 1.2.0), flight-starter (>= 2020.2.0), flight-starter (<< 2020.3.0), flight-env (>= 1.4.0), flight-env (<< 1.5.0), flight-desktop (>= 1.3.0), flight-desktop (<< 1.4.0), flight-job (>= 1.1.0), flight-job (<< 1.2.0), flight-howto (>= 1.0.2), flight-howto (<< 1.1.0)

--- a/builders/flight-user-suite/rpm/flight-user-suite.spec
+++ b/builders/flight-user-suite/rpm/flight-user-suite.spec
@@ -14,6 +14,8 @@ Requires:      flight-starter => 2020.2.0~, flight-starter < 2020.3.0~
 %{?el8:Recommends:    flight-plugin-system-starter}
 Requires:      flight-env => 1.4.0~, flight-env < 1.5.0~
 Requires:      flight-desktop => 1.3.0~, flight-desktop < 1.4.0~
+Requires:      flight-job => 1.1.0~, flight-job < 1.2.0~
+Requires:      flight-howto => 1.0.2~, flight-howto < 1.1.0~
 
 %description
 The Flight User Suite collection of tools and packages for running a HPC environment.
@@ -34,6 +36,8 @@ The Flight User Suite collection of tools and packages for running a HPC environ
 # Nothing to do
 
 %changelog
+* Mon Oct 19 2020 ben.armston@alces-flight.com - 2020.3-1
+- Added flight-job and flight-howto
 * Mon Jun 29 2020 Mark J. Titorenko <mark.titorenko@openflighthpc.org> - 2020.2-4
 - Cleaned up requires
 * Wed Apr  8 2020 Stu Franks <stu.franks@openflighthpc.org> - 2020.2-1


### PR DESCRIPTION
* Bump version to `2020.3`.
* Add `flight-job` and `flight-howto`.
* Update minimum version for `flight-runway` and `flight-starter`.