### PR TITLE
Use the system version of OpenSSL on Centos8

### DIFF
--- a/builders/flight-runway/config/projects/flight-runway.rb
+++ b/builders/flight-runway/config/projects/flight-runway.rb
@@ -35,7 +35,7 @@ VERSION = '1.1.4'
 override 'flight-runway', version: VERSION
 
 build_version VERSION
-build_iteration 3
+build_iteration 4
 
 dependency 'preparation'
 dependency 'flight-runway'
@@ -62,14 +62,9 @@ BUNDLER_VERSION = '2.1.4'
 override :bundler, version: BUNDLER_VERSION
 override :rubygems, version: '3.1.2'
 
-# This override is required to provide improved parity with the
-# version of `openssl` available in RHEL8 (1.1.1c at the time of
-# writing).
-if ohai['platform_family'] == 'rhel'
-  rhel_rel = ohai['platform_version'].split('.').first.to_i
-  if rhel_rel == 8
-    override :openssl, version: '1.1.1d'
-  end
+# Use the system version of OpenSSL on RHEL8
+if ohai['platform_family'] == 'rhel' && ohai['platform_version'].split('.').first.to_i == 8
+  runtime_dependency 'openssl-libs'
 elsif ohai['platform_family'] == 'debian'
   override :openssl, version: '1.1.1d'
 end

--- a/builders/flight-runway/config/software/flight-runway.rb
+++ b/builders/flight-runway/config/software/flight-runway.rb
@@ -31,13 +31,6 @@ source git: 'https://github.com/openflighthpc/flight-runway'
 
 dependency "ruby"
 dependency "rb-readline"
-if rhel? && platform_version.start_with?("8")
-  # In EL8, parts of `git` that link to curl have shared library
-  # dependencies that are incompatible with our embedded openssl build
-  # which causes issues when bundler needs to handle git repos, so we
-  # include curl in the embedded build.
-  dependency "curl"
-end
 dependency "bundler"
 dependency 'paint-gem'
 

--- a/builders/flight-runway/config/software/openssl.rb
+++ b/builders/flight-runway/config/software/openssl.rb
@@ -44,6 +44,13 @@ version("1.0.1s") { source sha256: "e7e81d82f3cd538ab0cdba494006d44aab9dd96b7f62
 relative_path "openssl-#{version}"
 
 build do
+  # Ensure openssl does not build on RHEL 8
+  block do
+    if ohai['platform_family'] == 'rhel' && ohai['platform_version'].split('.').first.to_i == 8
+      raise 'Embedded OpenSSL is not compatible with RHEL 8'
+    end
+  end
+
   env = with_standard_compiler_flags(with_embedded_path)
   if aix?
     env["M4"] = "/opt/freeware/bin/m4"

--- a/builders/flight-runway/config/software/ruby.rb
+++ b/builders/flight-runway/config/software/ruby.rb
@@ -28,9 +28,20 @@ skip_transitive_dependency_licensing true
 default_version "2.6.6"
 
 dependency "zlib"
-dependency "openssl"
 dependency "libffi"
 dependency "libyaml"
+
+# NOTE: The embedded openssl is not compatible on RHEL8,
+#       using the system version instead
+if ohai['platform_family'] == 'rhel' && ohai['platform_version'].split('.').first.to_i == 8
+  whitelist_file(/embedded\/lib\/ruby\/.+\/openssl\.so/)
+  whitelist_file(/embedded\/lib\/ruby\/.+\/digest\/md5\.so/)
+  whitelist_file(/embedded\/lib\/ruby\/.+\/digest\/rmd160\.so/)
+  whitelist_file(/embedded\/lib\/ruby\/.+\/digest\/sha1\.so/)
+  whitelist_file(/embedded\/lib\/ruby\/.+\/digest\/sha2\.so/)
+else
+  dependency 'openssl'
+end
 
 version("2.7.1")      { source sha256: "d418483bdd0000576c1370571121a6eb24582116db0b7bb2005e90e250eae418" }
 version("2.7.0")      { source sha256: "8c99aa93b5e2f1bc8437d1bbbefd27b13e7694025331f77245d0c068ef1f8cbe" }


### PR DESCRIPTION
Previously `flight-runway` was compiled with its own version of `OpenSSL`. AFAICS this is a legacy design decision back when the builder repo was forked from `omnibus-software` (or something to that affect).

I can see in the `config/projects/flight-runway.rb` there is some special casing for `openssl` on centos8, however this is not sufficient. There are a bunch of libraries (`pam`, `sudo`, `libkrb5`, `letsencrypt`, etc etc) which assume particular versions of `libcrypto.so.1.1`.

These assumptions work fine when the package manager controls the version of `openssl`, however they start to fail with out version. For example, an update to `libk5crypto.so.3` hobbled the flight ecosystem on `centos8`.

Instead of trying special case all the times `libcrypto.so.1.1` is used, a system dependency on `openssl-libs` has been added. It's next to guaranteed to be already installed.