### PR TITLE
Allow flight-pdsh to respect the system version

### DIFF
--- a/builders/flight-pdsh/config/projects/flight-pdsh.rb
+++ b/builders/flight-pdsh/config/projects/flight-pdsh.rb
@@ -52,6 +52,7 @@ exclude '**/.git'
 exclude '**/.gitkeep'
 exclude '**/bundler/git'
 
+extra_package_file "opt/flight/etc/flight-config-map.d/pdsh.yaml"
 %w(dshbak nodeattr pdcp pdsh rpdcp).each do |f|
   extra_package_file "opt/flight/opt/pdsh/bin/#{f}"
 end

--- a/builders/flight-pdsh/config/projects/flight-pdsh.rb
+++ b/builders/flight-pdsh/config/projects/flight-pdsh.rb
@@ -36,7 +36,7 @@ override 'pdsh', version: VERSION
 override 'readline', version: '6.0'
 
 build_version VERSION
-build_iteration 2
+build_iteration 3
 
 dependency 'preparation'
 dependency "genders"
@@ -65,6 +65,7 @@ package :rpm do
   # repurposed 'priority' field to set RPM recommends/provides
   # provides are prefixed with `:`
   # priority ""
+  priority ":flight-starter"
 end
 
 package :deb do
@@ -73,4 +74,5 @@ package :deb do
   # entire section is prefixed with `:` to trigger handling
   # provides are further prefixed with `:`
   # section ""
+  section ":flight-starter"
 end

--- a/builders/flight-pdsh/opt/flight/etc/flight-config-map.d/pdsh.yaml
+++ b/builders/flight-pdsh/opt/flight/etc/flight-config-map.d/pdsh.yaml
@@ -1,0 +1,4 @@
+pdsh:
+  priority:
+    var: 'flight_PDSH_priority'
+    file: 'pdsh'

--- a/builders/flight-pdsh/opt/flight/etc/profile.d/90-pdsh.csh
+++ b/builders/flight-pdsh/opt/flight/etc/profile.d/90-pdsh.csh
@@ -29,10 +29,11 @@ if ( -r "$flight_ROOT"/etc/pdsh.cshrc ) then
   source "$flight_ROOT"/etc/pdsh.cshrc
 endif
 
+if ( ! $?flight_PDSH_priority ) then
+  set flight_PDSH_priority='embedded'
+endif
+
 switch ("$flight_PDSH_priority")
-  case "":
-    set path=("$flight_ROOT"/opt/pdsh/bin $path)
-    breaksw
   case "embedded":
     set path=("$flight_ROOT"/opt/pdsh/bin $path)
     breaksw
@@ -43,5 +44,3 @@ switch ("$flight_PDSH_priority")
     set path=($path "$flight_ROOT"/opt/pdsh/bin)
     breaksw
 endsw
-
-unset $(env | grep ^flight_PDSH | cut -f1 -d= | xargs)

--- a/builders/flight-pdsh/opt/flight/etc/profile.d/90-pdsh.csh
+++ b/builders/flight-pdsh/opt/flight/etc/profile.d/90-pdsh.csh
@@ -24,4 +24,24 @@
 # For more information on OpenFlight Omnibus Builder, please visit:
 # https://github.com/openflighthpc/openflight-omnibus-builder
 #==============================================================================
-set path=(/opt/flight/opt/pdsh/bin $path)
+
+if ( -r "$flight_ROOT"/etc/pdsh.cshrc ) then
+  source "$flight_ROOT"/etc/pdsh.cshrc
+endif
+
+switch ("$flight_PDSH_priority")
+  case "":
+    set path=("$flight_ROOT"/opt/pdsh/bin $path)
+    breaksw
+  case "embedded":
+    set path=("$flight_ROOT"/opt/pdsh/bin $path)
+    breaksw
+  case "disabled":
+    # NOOP
+    breaksw
+  default:
+    set path=($path "$flight_ROOT"/opt/pdsh/bin)
+    breaksw
+endsw
+
+unset $(env | grep ^flight_PDSH | cut -f1 -d= | xargs)

--- a/builders/flight-pdsh/opt/flight/etc/profile.d/90-pdsh.sh
+++ b/builders/flight-pdsh/opt/flight/etc/profile.d/90-pdsh.sh
@@ -24,4 +24,21 @@
 # For more information on OpenFlight Omnibus Builder, please visit:
 # https://github.com/openflighthpc/openflight-omnibus-builder
 #==============================================================================
-export PATH=/opt/flight/opt/pdsh/bin:$PATH
+
+if [ -r "$flight_ROOT"/etc/pdsh.rc ]; then
+  source "$flight_ROOT"/etc/pdsh.rc
+fi
+
+case ${flight_PDSH_priority:-embedded} in
+  embedded)
+    export PATH="$flight_ROOT"/opt/pdsh/bin:$PATH
+    ;;
+  disabled)
+    # NOOP
+    ;;
+  *) # "system" is the canonical trigger term here
+    export PATH=$PATH:"$flight_ROOT"/opt/pdsh/bin
+    ;;
+esac
+
+unset $(declare | grep ^flight_PDSH | cut -f1 -d= | xargs)

--- a/builders/flight-pdsh/resources/flight-pdsh/rpm/spec.erb
+++ b/builders/flight-pdsh/resources/flight-pdsh/rpm/spec.erb
@@ -43,10 +43,12 @@ if priority != 'extra'
     end
   end
 
-  recommends.each do |name|
+  unless dist_tag.include? '7'
+    recommends.each do |name|
 -%>
 Recommends: <%= name %>
 <%
+    end
   end
 -%>
 <%

--- a/builders/flight-starter/build.sh
+++ b/builders/flight-starter/build.sh
@@ -5,9 +5,9 @@ mkdir -p pkg
 
 NOW=2020.3
 NEXT=2020.4
-VERSION=${NOW}.0~rc1
+VERSION=${NOW}.1~rc3
 TAG=$(echo "$VERSION" | sed "s/~/-/g")
-REL=2
+REL=1
 
 if [ -f /etc/redhat-release ]; then
   echo "Building RPM package..."

--- a/builders/flight-starter/build.sh
+++ b/builders/flight-starter/build.sh
@@ -3,9 +3,10 @@ cd "$(dirname "$0")"
 d="$(pwd)"
 mkdir -p pkg
 
-NOW=2020.2
-NEXT=2020.3
-VERSION=${NOW}.6
+NOW=2020.3
+NEXT=2020.4
+VERSION=${NOW}.0~rc1
+TAG=$(echo "$VERSION" | sed "s/~/-/g")
 REL=2
 
 if [ -f /etc/redhat-release ]; then
@@ -13,6 +14,7 @@ if [ -f /etc/redhat-release ]; then
   cd rpm
   rpmbuild -bb flight-starter.spec \
            --define "_flight_pkg_version $VERSION" \
+           --define "_flight_pkg_tag $TAG" \
            --define "_flight_pkg_rel $REL" \
            --define "_flight_pkg_now $NOW" \
            --define "_flight_pkg_next $NEXT"
@@ -61,9 +63,9 @@ elif [ -f /etc/lsb-release ]; then
       $d/deb/flight-starter-banner.control.tpl > \
       $HOME/flight-starter/flight-starter-banner_${VERSION}-${REL}/DEBIAN/control
 
-  wget https://github.com/openflighthpc/flight-starter/archive/${VERSION}.tar.gz
-  tar xzf ${VERSION}.tar.gz
-  mv flight-starter-${VERSION}/dist/* flight-starter_${VERSION}-${REL}
+  wget https://github.com/openflighthpc/flight-starter/archive/${TAG}.tar.gz
+  tar xzf ${TAG}.tar.gz
+  mv flight-starter-${TAG}/dist/* flight-starter_${VERSION}-${REL}
 
   # flight-starter-banner
   for a in /opt/flight/etc/flight-starter.rc \

--- a/builders/flight-starter/build.sh
+++ b/builders/flight-starter/build.sh
@@ -5,7 +5,7 @@ mkdir -p pkg
 
 NOW=2020.3
 NEXT=2020.4
-VERSION=${NOW}.1~rc4
+VERSION=${NOW}.1~rc7
 TAG=$(echo "$VERSION" | sed "s/~/-/g")
 REL=1
 

--- a/builders/flight-starter/build.sh
+++ b/builders/flight-starter/build.sh
@@ -5,7 +5,7 @@ mkdir -p pkg
 
 NOW=2020.3
 NEXT=2020.4
-VERSION=${NOW}.1~rc7
+VERSION=${NOW}.1~rc10
 TAG=$(echo "$VERSION" | sed "s/~/-/g")
 REL=1
 

--- a/builders/flight-starter/build.sh
+++ b/builders/flight-starter/build.sh
@@ -5,7 +5,7 @@ mkdir -p pkg
 
 NOW=2020.3
 NEXT=2020.4
-VERSION=${NOW}.1~rc3
+VERSION=${NOW}.1~rc4
 TAG=$(echo "$VERSION" | sed "s/~/-/g")
 REL=1
 

--- a/builders/flight-starter/rpm/flight-starter.spec
+++ b/builders/flight-starter/rpm/flight-starter.spec
@@ -8,7 +8,7 @@ License:        EPL-2.0
 
 URL:            https://openflighthpc.org
 %undefine _disable_source_fetch
-Source0:        https://github.com/openflighthpc/%{name}/archive/%{version}.tar.gz
+Source0:        https://github.com/openflighthpc/%{name}/archive/%{_flight_pkg_tag}.tar.gz
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
@@ -20,7 +20,7 @@ Requires:      flight-runway, flight-starter-banner => %{_flight_pkg_now}.0, fli
 Profile scripts and infrastructure for activating an OpenFlight HPC environment
 
 %prep
-%setup -q
+%setup -q -n %{name}-%{_flight_pkg_tag}
 
 %build
 
@@ -50,6 +50,8 @@ install -p -m 644 $RPM_BUILD_ROOT/etc/xdg/flight.cshrc $RPM_BUILD_ROOT/opt/fligh
 /opt/flight/libexec/commands/*
 %dir /opt/flight/libexec/flight-starter/
 /opt/flight/libexec/flight-starter/*
+%dir /opt/flight/lib/flight-starter-patches/
+/opt/flight/lib/flight-starter-patches/*
 %exclude /opt/flight/libexec/flight-starter/banner
 
 %changelog

--- a/builders/flight-starter/rpm/flight-starter.spec
+++ b/builders/flight-starter/rpm/flight-starter.spec
@@ -12,9 +12,12 @@ Source0:        https://github.com/openflighthpc/%{name}/archive/%{_flight_pkg_t
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
-BuildArch:     noarch
-Requires:      flight-runway, flight-starter-banner => %{_flight_pkg_now}.0, flight-starter-banner < %{_flight_pkg_next}.0~, flight-starter-system-1.0
+BuildArch:      noarch
+Requires:       flight-runway, flight-starter-banner => %{_flight_pkg_now}.0, flight-starter-banner < %{_flight_pkg_next}.0~, flight-starter-system-1.0
 %{?el8:Recommends:    flight-plugin-system-starter}
+
+# Required in the post install script
+Requires:       diffutils
 
 %description
 Profile scripts and infrastructure for activating an OpenFlight HPC environment
@@ -43,7 +46,7 @@ install -p -m 644 $RPM_BUILD_ROOT/etc/xdg/flight.cshrc $RPM_BUILD_ROOT/opt/fligh
 /opt/flight/etc/banner/banner.d/*
 /opt/flight/etc/banner/tips.d/*
 %config(noreplace) /opt/flight/etc/setup-sshkey.rc
-%config(noreplace) /opt/flight/etc/flight-config-map.yml
+/opt/flight/etc/flight-config-map.d/*
 /opt/flight/etc/profile.d/*
 /opt/flight/etc/setup.sh
 /opt/flight/etc/setup.csh
@@ -53,6 +56,18 @@ install -p -m 644 $RPM_BUILD_ROOT/etc/xdg/flight.cshrc $RPM_BUILD_ROOT/opt/fligh
 %dir /opt/flight/lib/flight-starter-patches/
 /opt/flight/lib/flight-starter-patches/*
 %exclude /opt/flight/libexec/flight-starter/banner
+
+%post
+old=/opt/flight/etc/flight-config-map.yml
+new=/opt/flight/etc/flight-config-map.d/zz-cluster.yml
+sys=/opt/flight/etc/flight-config-map.d/cluster.yml
+if [ -e "$old" ]; then
+  if cmp "$old" "$sys" >/dev/null; then
+    rm -f "$old"
+  else
+    mv "$old" "$new"
+  fi
+fi
 
 %changelog
 * Wed Jun 24 2020 Mark J. Titorenko <mark.titorenko@alces-flight.com> - 2020.2.x


### PR DESCRIPTION
The `flight-pdsh` utility by default is added to the start of the `PATH` which overrides the system version. Instead it can be added to the end of the path with:

```
flight config set pdsh.priority system
```

Or it can be disabled with:

```
flight config set pdsh.priority disabled
```