### PR TITLE
Update the howto guides to render nicely with groff

### DIFF
--- a/builders/flight-desktop/contrib/howto/1.3
+++ b/builders/flight-desktop/contrib/howto/1.3
@@ -1,4 +1,6 @@
-# Flight Desktop
+# flight-desktop(1)
+
+## Overview
 
 Manage interactive desktop sessions
 

--- a/builders/flight-desktop/contrib/howto/1.3
+++ b/builders/flight-desktop/contrib/howto/1.3
@@ -49,22 +49,17 @@ $ flight desktop --help
 
 The different types of desktop sessions can be returned with `avail`:
 
-~~~
-+----------+---------------------------------------------------------------------------------------+------------+
-| Name     | Summary                                                                               | State      |
-+----------+---------------------------------------------------------------------------------------+------------+
-| chrome   | Full-screen Google Chrome browser session.                                            | Unverified |
-|          |                                                                                       |            |
-|          |  > https://www.google.com/chrome/                                                     |            |
-|          |                                                                                       |            |
-| gnome    | GNOME v3, a free and open-source desktop environment for Unix-like operating systems. | Unverified |
-|          |                                                                                       |            |
-|          |  > https://www.gnome.org/                                                             |            |
-|          |                                                                                       |            |
-| terminal | Preconfigured terminal for Flight HPC environments.                                   | Unverified |
-...
-+----------+---------------------------------------------------------------------------------------+------------+
-~~~
+| Name     | Summary                                             | State      |
+|----------|-----------------------------------------------------|------------|
+| chrome   | Full-screen Google Chrome browser session.          | Unverified |
+| &#9;     | &#9;                                                | &#9;       |
+| &#9;     |  `>` https://www.google.com/chrome/                 | &#9;       |
+| &#9;     | &#9;                                                | &#9;       |
+| gnome    | GNOME v3, a free and open-source desktop            | Unverified |
+| &#9;     | environment for Unix-like operating systems.        | &#9;       |
+| &#9;     | &#9;                                                | &#9;       |
+| &#9;     |  `>` https://www.gnome.org/                         | &#9;       |
+| ...      | ...                                                 | ...        |
 
 ## Verifying and Installing a Desktop
 
@@ -76,13 +71,13 @@ required packages.
 $ flight desktop verify gnome
 Verifying desktop type gnome:
 
-   > OK Flight Desktop prerequisites 
+   > OK Flight Desktop prerequisites
    > NO Prerequisite: polkit policies
    > OK Package group: X Window System
-   > NO Package group: Fonts         
-   > OK Package group: GNOME         
-   > NO Package: evince 
-   > NO Package: firefox 
+   > NO Package group: Fonts
+   > OK Package group: GNOME
+   > NO Package: evince
+   > NO Package: firefox
 
 Desktop type gnome has missing prerequisites:
 
@@ -105,9 +100,9 @@ Once the required packages are installed, the desktop will verify successfully:
 $ flight desktop verify terminal
 Verifying desktop type terminal:
 
-   > OK Flight Desktop prerequisites 
-   > OK Package: xorg-x11-server-utils 
-   > OK Package: xterm 
+   > OK Flight Desktop prerequisites
+   > OK Package: xorg-x11-server-utils
+   > OK Package: xterm
 
 Desktop type terminal has been verified.
 ~~~
@@ -120,7 +115,7 @@ A new session can be created with the `start` command:
 $ flight desktop start terminal
 Starting a 'terminal' desktop session:
 
-   > OK Starting session 
+   > OK Starting session
 
 A 'terminal' desktop session has been started.
 
@@ -152,12 +147,12 @@ The running sessions are returned by the `list` command:
 
 ~~~
 $ flight desktop list
-+----------+----------+-----------+------------+----------------+----------+--------+
-| Identity | Type     | Host name | IP address | Display (Port) | Password | State  |
-+----------+----------+-----------+------------+----------------+----------+--------+
-| 7d6d8b87 | terminal | master    | 10.10.0.1  | :1 (5923)      | XXXXXXXX | Active |
-+----------+----------+-----------+------------+----------------+----------+--------+
 ~~~
+
+| Identity | Type  | Host name | IP address | Display   | Password | State  |
+|----------|-------|-----------|------------|-----------|----------|--------|
+| 7d6d8b87 | gnome | master    | 10.10.0.1  | :1 (5923) | XXXXXXXX | Active |
+| ...      | ...   | ...       | ...        | ...       | ...      | ...    |
 
 ## Terminate a Session
 
@@ -168,7 +163,7 @@ full ID.
 $ flight desktop kill 7d6d8b87
 Killing desktop session 7d6d8b87-e32c-4f16-8362-9e15f90e69e2:
 
-   > OK Terminating session 
+   > OK Terminating session
 
 Desktop session '7d6d8b87-e32c-4f16-8362-9e15f90e69e2' has been terminated.
 ~~~

--- a/builders/flight-desktop/contrib/howto/1.3
+++ b/builders/flight-desktop/contrib/howto/1.3
@@ -1,8 +1,6 @@
-# flight-desktop(1)
+# Flight Desktop(1) - manage interactive GUI desktop sessions
 
 ## Overview
-
-Manage interactive desktop sessions
 
 ~~~
 $ flight desktop --help

--- a/builders/flight-env/contrib/howto/1.4
+++ b/builders/flight-env/contrib/howto/1.4
@@ -44,20 +44,19 @@ The available environments can be found with the `avail` command:
 
 ~~~
 $ flight env avail
-+-------------+-------------------------------------------------------------------------+
-| Name        | Summary                                                                 |
-+-------------+-------------------------------------------------------------------------+
-...
-| gridware    | Tool for installing and managing scientific applications and libraries. |
-|             |                                                                         |
-|             |  > https://gridware.alces-flight.com/                                   |
-|             |                                                                         |
-| modules     | Provides dynamic modification of a user's environment.                  |
-|             |                                                                         |
-|             |  > http://modules.sourceforge.net/                                      |
-...
-+-------------+-------------------------------------------------------------------------+
 ~~~
+
+| Name     | Summary                                                  |
+|----------|----------------------------------------------------------|
+| gridware | Tool for installing and managing scientific applications |
+| &#9;     | and libraries.                                           |
+| &#9;     | &#9;                                                     |
+| &#9;     |  `>` https://gridware.alces-flight.com/                  |
+| &#9;     | &#9;                                                     |
+| modules  | Provides dynamic modification of a user's environment.   |
+| &#9;     | &#9;                                                     |
+| &#9;     |  `>` http://modules.sourceforge.net/                     |
+| ...      | ...                                                      |
 
 ## Install, List and Remove an Environment
 
@@ -88,12 +87,11 @@ The environments which have been installed can be retrieved with the `list` comm
 
 ~~~
 $ flight env list
-+------------------+-------+
-| Name             | Scope |
-+------------------+-------+
-| gridware@default | user  |
-+------------------+-------+
 ~~~
+
+| Name             | Scope |
+|------------------|-------|
+| gridware@default | user  |
 
 The environment can be removed with the `purge` command:
 

--- a/builders/flight-env/contrib/howto/1.4
+++ b/builders/flight-env/contrib/howto/1.4
@@ -1,4 +1,6 @@
-# Flight ENV
+# flight-env(1)
+
+## Overview
 
 Manage and access HPC environment
 

--- a/builders/flight-env/contrib/howto/1.4
+++ b/builders/flight-env/contrib/howto/1.4
@@ -1,8 +1,6 @@
-# flight-env(1)
+# Flight ENV(1) - Manage and access HPC environment
 
 ## Overview
-
-Manage and access HPC environment
 
 ~~~
 $ flight env --help

--- a/builders/flight-estate/contrib/howto/1.1
+++ b/builders/flight-estate/contrib/howto/1.1
@@ -1,4 +1,6 @@
-# Flight Estate
+# flight-estate(1)
+
+## Overview
 
 Manage the instance types and size of your compute estate
 

--- a/builders/flight-estate/contrib/howto/1.1
+++ b/builders/flight-estate/contrib/howto/1.1
@@ -1,8 +1,6 @@
-# flight-estate(1)
+# Flight Estate(1) - Manage the machine types and size of your compute estate
 
 ## Overview
-
-Manage the instance types and size of your compute estate
 
 ~~~
 $ flight estate --help

--- a/builders/flight-howto/opt/flight/usr/share/howto/01-get-started.md
+++ b/builders/flight-howto/opt/flight/usr/share/howto/01-get-started.md
@@ -1,4 +1,4 @@
-# How To Get Started
+# getting-started(7)
 
 ## What is OpenFlightHPC?
 

--- a/builders/flight-howto/opt/flight/usr/share/howto/01-get-started.md
+++ b/builders/flight-howto/opt/flight/usr/share/howto/01-get-started.md
@@ -1,4 +1,4 @@
-# getting-started(7)
+# How To Get Started(7)
 
 ## What is OpenFlightHPC?
 

--- a/builders/flight-howto/opt/flight/usr/share/howto/02-work-with-the-flight-environment.md
+++ b/builders/flight-howto/opt/flight/usr/share/howto/02-work-with-the-flight-environment.md
@@ -1,4 +1,4 @@
-# working-with-flight(7)
+# Working with Flight(7)
 
 ## Activating the Flight System
 

--- a/builders/flight-howto/opt/flight/usr/share/howto/02-work-with-the-flight-environment.md
+++ b/builders/flight-howto/opt/flight/usr/share/howto/02-work-with-the-flight-environment.md
@@ -1,4 +1,4 @@
-# How To Work with the Flight Environment
+# working-with-flight(7)
 
 ## Activating the Flight System
 

--- a/builders/flight-howto/opt/flight/usr/share/howto/03-use-flight-user-suite.md
+++ b/builders/flight-howto/opt/flight/usr/share/howto/03-use-flight-user-suite.md
@@ -1,4 +1,4 @@
-# How To Use Flight User Suite
+# flight-user-suite(7)
 
 ## What is Flight User Suite?
 

--- a/builders/flight-howto/opt/flight/usr/share/howto/03-use-flight-user-suite.md
+++ b/builders/flight-howto/opt/flight/usr/share/howto/03-use-flight-user-suite.md
@@ -1,4 +1,4 @@
-# flight-user-suite(7)
+# Flight User Suite(7)
 
 ## What is Flight User Suite?
 

--- a/builders/flight-howto/opt/flight/usr/share/howto/04-run-jobs.md
+++ b/builders/flight-howto/opt/flight/usr/share/howto/04-run-jobs.md
@@ -1,4 +1,4 @@
-# running-jobs(7)
+# How To Run Jobs(7)
 
 ## What is a job?
 

--- a/builders/flight-howto/opt/flight/usr/share/howto/04-run-jobs.md
+++ b/builders/flight-howto/opt/flight/usr/share/howto/04-run-jobs.md
@@ -1,4 +1,4 @@
-# How To Run Jobs
+# running-jobs(7)
 
 ## What is a job?
 

--- a/builders/flight-howto/opt/flight/usr/share/howto/05-use-a-scheduler.md
+++ b/builders/flight-howto/opt/flight/usr/share/howto/05-use-a-scheduler.md
@@ -1,4 +1,4 @@
-# How To Use a Scheduler
+# using-a-scheduler(7)
 
 ## What is a batch job scheduler?
 

--- a/builders/flight-howto/opt/flight/usr/share/howto/05-use-a-scheduler.md
+++ b/builders/flight-howto/opt/flight/usr/share/howto/05-use-a-scheduler.md
@@ -1,4 +1,4 @@
-# using-a-scheduler(7)
+# Using a Scheduler(7)
 
 ## What is a batch job scheduler?
 

--- a/builders/flight-job/contrib/howto/1.1
+++ b/builders/flight-job/contrib/howto/1.1
@@ -1,8 +1,6 @@
-# flight-job(1)
+# Flight Job(1) - Generate a job script from a predefined template
 
 ## Overview
-
-Generate a job script from a predefined template.
 
 ~~~
 $ flight job --help

--- a/builders/flight-job/contrib/howto/1.1
+++ b/builders/flight-job/contrib/howto/1.1
@@ -1,4 +1,6 @@
-# Flight Job
+# flight-job(1)
+
+## Overview
 
 Generate a job script from a predefined template.
 

--- a/builders/flight-power/contrib/howto/1.1
+++ b/builders/flight-power/contrib/howto/1.1
@@ -1,8 +1,6 @@
-# flight-power(1)
+# Flight Power(1) - Manage the power state of the nodes
 
 ## Overview
-
-Manage the power state of the nodes
 
 ~~~
 $ flight power --help

--- a/builders/flight-power/contrib/howto/1.1
+++ b/builders/flight-power/contrib/howto/1.1
@@ -1,4 +1,6 @@
-# Flight Power
+# flight-power(1)
+
+## Overview
 
 Manage the power state of the nodes
 


### PR DESCRIPTION
There are two changes contained within this PR:

1. The guides now use groff friendly titles and section numbers
2. A couple of the tables have been updated to render using `groff` instead of being within a fenced code block.

The problem with using fenced code blocks is they are double indented. This is the intended behaviour most of the time, however it takes up 11 characters. Also the previous tables vertically delimited the columns, which takes additional characters.

Because the output needs to be `groff` friendly, it should not exceed 80 characters wide. Whilst the document will still render, it breaks the visual flow of the document.

By allowing `groff` to render the table, the indent is reduced to 7 characters and the vertical delimiting is removed. This corresponds to approximately a 10% increase in the maximum table width.

I had a couple of issues with getting blank cells to render correctly and in the end had to put in "decimal encoded html tab characters"  (`&#9;`) to prevent `groff` from getting confused. Also because the `html` intermediary document, greater than `>` needs to be placed within an inline code block. Both of these compatibility fixes continue to function when the `html` intermediary is removed.