### PR TITLE
Only create a genders file in flight-pdsh if missing

### DIFF
--- a/builders/flight-pdsh/config/projects/flight-pdsh.rb
+++ b/builders/flight-pdsh/config/projects/flight-pdsh.rb
@@ -36,7 +36,7 @@ override 'pdsh', version: VERSION
 override 'readline', version: '6.0'
 
 build_version VERSION
-build_iteration 4
+build_iteration 5
 
 dependency 'preparation'
 dependency "genders"
@@ -56,7 +56,6 @@ extra_package_file "opt/flight/etc/flight-config-map.d/pdsh.yaml"
 %w(dshbak nodeattr pdcp pdsh rpdcp).each do |f|
   extra_package_file "opt/flight/opt/pdsh/bin/#{f}"
 end
-extra_package_file "opt/flight/etc/genders"
 %w(sh csh).each do |ext|
   extra_package_file "opt/flight/etc/profile.d/90-pdsh.#{ext}"
 end

--- a/builders/flight-pdsh/package-scripts/flight-pdsh/postinst
+++ b/builders/flight-pdsh/package-scripts/flight-pdsh/postinst
@@ -1,6 +1,6 @@
 #!/bin/sh
 #==============================================================================
-# Copyright (C) 2019-present Alces Flight Ltd.
+# Copyright (C) 2021-present Alces Flight Ltd.
 #
 # This file is part of OpenFlight Omnibus Builder.
 #

--- a/builders/flight-pdsh/package-scripts/flight-pdsh/postinst
+++ b/builders/flight-pdsh/package-scripts/flight-pdsh/postinst
@@ -1,0 +1,33 @@
+#!/bin/sh
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of OpenFlight Omnibus Builder.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on OpenFlight Omnibus Builder, please visit:
+# https://github.com/openflighthpc/openflight-omnibus-builder
+#===============================================================================
+
+if [ ! -f "/opt/flight/etc/genders" ]; then
+  touch "/opt/flight/etc/genders"
+fi
+
+exit 0


### PR DESCRIPTION
The genders file may exist before installing `flight-pdsh` and should not be modified. An empty genders file should only be added if missing.
