### PR TITLE
Remove falcon-get-pid from the scheduler-controller scripts

### DIFF
--- a/builders/flight-scheduler-controller/config/projects/flight-scheduler-controller.rb
+++ b/builders/flight-scheduler-controller/config/projects/flight-scheduler-controller.rb
@@ -34,7 +34,7 @@ install_dir '/opt/flight/opt/scheduler-controller'
 VERSION = '0.7.0'
 override 'flight-scheduler-controller', version: VERSION
 build_version VERSION
-build_iteration 1
+build_iteration 2
 
 dependency 'preparation'
 dependency 'flight-scheduler-controller'

--- a/builders/flight-scheduler-controller/opt/flight/etc/service/types/scheduler-controller/restart.sh
+++ b/builders/flight-scheduler-controller/opt/flight/etc/service/types/scheduler-controller/restart.sh
@@ -28,14 +28,15 @@
 
 # Get the source directory
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+OLD_PID=(cat "$1")
 
 # NOTE: The PID is determined via the supervisor.ipc socket
-bash "$DIR"/stop.sh
+bash "$DIR"/stop.sh "$1"
 
 # Wait up to 10ish seconds for falcon to stop
 app_root="$flight_ROOT/opt/scheduler-controller"
 for _ in `seq 1 20`; do
-  "$flight_ROOT"/bin/ruby "$app_root"/bin/get-falcon-pid.rb "$app_root"/supervisor.ipc
+  kill -0 "$OLD_PID" 2>/dev/null
   state=$?
   if [ "$state" -ne 0 ]; then
     break

--- a/builders/flight-scheduler-controller/opt/flight/etc/service/types/scheduler-controller/stop.sh
+++ b/builders/flight-scheduler-controller/opt/flight/etc/service/types/scheduler-controller/stop.sh
@@ -26,10 +26,7 @@
 # https://github.com/openflighthpc/openflight-omnibus-builder
 #===============================================================================
 
-app_root="$flight_ROOT/opt/scheduler-controller"
-pid=$("$flight_ROOT"/bin/ruby "$app_root"/bin/get-falcon-pid.rb "$app_root"/supervisor.ipc)
+pid=$(cat "$1")
 if [ "$pid" ]; then
-  # NOTE: Sending to the process group as the PID corresponds to the wrapper
-  #       script and not the falcon process. Change as required
-  kill -s SIGINT -- "-$pid"
+  kill -s SIGINT "$pid"
 fi

--- a/builders/flight-scheduler-controller/opt/flight/opt/scheduler-controller/bin/start
+++ b/builders/flight-scheduler-controller/opt/flight/opt/scheduler-controller/bin/start
@@ -33,4 +33,8 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null 2>&1 && pwd )"
 log_path="$flight_ROOT"/var/log/scheduler-controller/falcon.log
 mkdir -p $(dirname "$log_path")
 
-"$flight_ROOT"/bin/ruby "$DIR"/bin/falcon-host "$DIR"/falcon.rb >>"$log_path" 2>&1
+# Write the PID
+echo $$ >"$1"
+
+# Turn into the falcon process
+exec "$flight_ROOT"/bin/ruby "$DIR"/bin/falcon-host "$DIR"/falcon.rb >>"$log_path" 2>&1


### PR DESCRIPTION
Based on #68

Canonically the `falcon` web server relies on a controller process to be responsible for starting/stopping/restarting it. As such the infrastructure underpinning `falcon-get-pid` is designed to return the parent process identifier (PPID) not the PID.

In the context of `flight-scheduler-controller`, the PPID is a bash wrapper script (`bin/start`) which does not provide the same "controller" functionality `falcon` is expecting. This can causes various issues if the wrapper exits without the `falcon` daemon being killed (such as the PPID/PID becoming 1).

It has proven to be a difficult task to get the PID through the `get-falcon-pid` script/infrastructure and as such it has been removed. Instead the service `start`/`stop`/`restart` scripts have been remodelled to behaviour closer to `puma` scripts.