### PR TITLE
Rework nodejs version numbering

### DIFF
--- a/builders/flight-console-api/config/projects/flight-console-api.rb
+++ b/builders/flight-console-api/config/projects/flight-console-api.rb
@@ -35,7 +35,7 @@ VERSION = '1.0.0'
 override 'flight-console-api', version: VERSION
 
 build_version VERSION
-build_iteration 2
+build_iteration 3
 
 dependency 'preparation'
 dependency 'flight-console-api'
@@ -51,7 +51,7 @@ exclude '**/.gitkeep'
 
 runtime_dependency 'flight-service-system-1.0'
 runtime_dependency 'flight-nodejs'
-runtime_dependency 'flight-js-system-1.0'
+runtime_dependency 'flight-js-system-2.0'
 runtime_dependency 'flight-www'
 runtime_dependency 'flight-www-system-1.0'
 

--- a/builders/flight-file-manager-api/config/projects/flight-file-manager-api.rb
+++ b/builders/flight-file-manager-api/config/projects/flight-file-manager-api.rb
@@ -36,7 +36,7 @@ override 'flight-file-manager-api', version: VERSION
 override 'flight-file-manager-backend', version: VERSION
 
 build_version VERSION
-build_iteration 1
+build_iteration 2
 
 dependency 'preparation'
 dependency 'flight-file-manager-api'
@@ -58,8 +58,14 @@ runtime_dependency 'flight-www'
 runtime_dependency 'flight-www-system-1.0'
 runtime_dependency 'flight-service'
 runtime_dependency 'flight-service-system-1.0'
-runtime_dependency 'flight-nodejs'
-runtime_dependency 'flight-js-system-1.0'
+runtime_dependency 'flight-js-system-2.0'
+if ohai['platform_family'] == 'rhel'
+  runtime_dependency 'flight-nodejs >= 14.15.4'
+elsif ohai['platform_family'] == 'debian'
+  runtime_dependency 'flight-nodejs (>= 14.15.4)'
+else
+  raise "Unrecognised platform: #{ohai['platform_family']}"
+end
 
 config_file File.join(install_dir, 'etc/flight-file-manager.yaml')
 

--- a/builders/flight-file-manager-api/config/software/enforce-flight-nodejs.rb
+++ b/builders/flight-file-manager-api/config/software/enforce-flight-nodejs.rb
@@ -34,5 +34,12 @@ skip_transitive_dependency_licensing true
 build do
   block do
     raise "Flight NodeJS is not installed!" if ! File.exists?('/opt/flight/bin/yarn')
+    nodejs_version = `/opt/flight/bin/node --version`.chomp
+    major, minor, _patch = nodejs_version.sub(/^v/, '').split('.')
+    if major.to_i < 14
+      raise "Flight NodeJS has incorrect version: #{nodejs_version} (expected 14.15.x)"
+    elsif major.to_i == 14 && minor.to_i < 15
+      raise "Flight NodeJS has incorrect version: #{nodejs_version} (expected 14.15.x)"
+    end
   end
 end

--- a/builders/flight-nodejs/config/projects/flight-nodejs.rb
+++ b/builders/flight-nodejs/config/projects/flight-nodejs.rb
@@ -31,7 +31,7 @@ friendly_name 'Flight NodeJS'
 
 install_dir '/opt/flight/opt/nodejs'
 
-NODEJS_VERSION = '12.16.3'
+NODEJS_VERSION = '14.15.4'
 VERSION = NODEJS_VERSION
 override 'flight-nodejs', version: VERSION
 

--- a/builders/flight-nodejs/config/projects/flight-nodejs.rb
+++ b/builders/flight-nodejs/config/projects/flight-nodejs.rb
@@ -31,7 +31,8 @@ friendly_name 'Flight NodeJS'
 
 install_dir '/opt/flight/opt/nodejs'
 
-VERSION = '1.1.0'
+NODEJS_VERSION = '12.16.3'
+VERSION = NODEJS_VERSION
 override 'flight-nodejs', version: VERSION
 
 build_version VERSION
@@ -41,8 +42,12 @@ dependency 'preparation'
 dependency 'flight-nodejs'
 dependency 'version-manifest'
 
-JS_SYSTEM = '1.0'
-override 'nodejs', version: '14.15.4'
+# JS_SYSTEM 2.0 represents a versioning scheme where `flight-nodejs` tracks
+# the upstream nodejs version.  I.e., `flight-nodejs-14.15.4` installs nodejs
+# 14.15.4.
+JS_SYSTEM = '2.0'
+
+override 'nodejs', version: NODEJS_VERSION
 override 'yarn', version: '1.22.4'
 
 license 'EPL-2.0'


### PR DESCRIPTION
It now follows the same versioning used upstream.  That is, `flight-nodejs-12.16.3` installs nodejs version 12.16.3.  The `flight-js-system` has been updated to allow packages to depend on the new versioning scheme.