### PR TITLE
Job script webapp auth

### DIFF
--- a/builders/flight-console-webapp/omnibus.rb
+++ b/builders/flight-console-webapp/omnibus.rb
@@ -39,7 +39,7 @@
 #
 # Uncomment this line to change the default base directory to "local"
 # -------------------------------------------------------------------
-base_dir '/home/vagrant/fligth-console-webapp/local'
+base_dir '/home/vagrant/flight-console-webapp/local'
 
 append_timestamp false
 #

--- a/builders/flight-desktop-webapp/omnibus.rb
+++ b/builders/flight-desktop-webapp/omnibus.rb
@@ -39,7 +39,7 @@
 #
 # Uncomment this line to change the default base directory to "local"
 # -------------------------------------------------------------------
-base_dir '/home/vagrant/fligth-desktop-webapp/local'
+base_dir '/home/vagrant/flight-desktop-webapp/local'
 
 append_timestamp false
 #

--- a/builders/flight-file-manager-webapp/omnibus.rb
+++ b/builders/flight-file-manager-webapp/omnibus.rb
@@ -39,7 +39,7 @@
 #
 # Uncomment this line to change the default base directory to "local"
 # -------------------------------------------------------------------
-base_dir '/home/vagrant/fligth-file-manager-webapp/local'
+base_dir '/home/vagrant/flight-file-manager-webapp/local'
 
 append_timestamp false
 #

--- a/builders/flight-job-script-webapp/config/projects/flight-job-script-webapp.rb
+++ b/builders/flight-job-script-webapp/config/projects/flight-job-script-webapp.rb
@@ -31,11 +31,11 @@ friendly_name 'Flight Job Script Webapp'
 
 install_dir '/opt/flight/opt/job-script-webapp'
 
-VERSION = '0.8.1'
+VERSION = '0.8.2'
 override 'flight-job-script-webapp', version: VERSION
 
 build_version VERSION
-build_iteration 2
+build_iteration 1
 
 dependency 'preparation'
 dependency 'flight-job-script-webapp'

--- a/builders/flight-job-script-webapp/omnibus.rb
+++ b/builders/flight-job-script-webapp/omnibus.rb
@@ -39,7 +39,7 @@
 #
 # Uncomment this line to change the default base directory to "local"
 # -------------------------------------------------------------------
-base_dir '/home/vagrant/fligth-job-script-webapp/local'
+base_dir '/home/vagrant/flight-job-script-webapp/local'
 
 append_timestamp false
 #


### PR DESCRIPTION
 * Update `flight-job-script-webapp` to use `flight-webapp-components`
 * Fix typos in directories used in omnibus builds.  These typos do not bleed through to the RPMs.