### PR TITLE
Rolling PR for flight-desktop to version 1.5.0-cX

### DIFF
--- a/builders/flight-desktop/config/projects/flight-desktop.rb
+++ b/builders/flight-desktop/config/projects/flight-desktop.rb
@@ -31,7 +31,7 @@ friendly_name 'Flight Desktop'
 
 install_dir '/opt/flight/opt/desktop'
 
-VERSION = '1.4.0'
+VERSION = '1.5.0-c1'
 override 'flight-desktop', version: VERSION
 
 build_version VERSION

--- a/builders/flight-desktop/opt/flight/libexec/commands/desktop
+++ b/builders/flight-desktop/opt/flight/libexec/commands/desktop
@@ -1,7 +1,7 @@
 : '
 : NAME: desktop
 : SYNOPSIS: Manage interactive GUI desktop sessions
-: VERSION: 1.5.0-b3
+: VERSION: 1.5.0-c1
 : '
 #==============================================================================
 # Copyright (C) 2019-present Alces Flight Ltd.


### PR DESCRIPTION
The previous `1.4.0.bX` release series was made in error, this is actually going to become part of the `1.5.0` release