### PR TITLE
Use the non-interactive configure in flight-action-api

### DIFF
--- a/builders/flight-action-api/config/projects/flight-action-api.rb
+++ b/builders/flight-action-api/config/projects/flight-action-api.rb
@@ -36,7 +36,7 @@ VERSION = '1.4.0'
 override 'flight-action-api', version: VERSION
 
 build_version VERSION
-build_iteration 1
+build_iteration 2
 
 dependency 'preparation'
 dependency 'flight-action-api'

--- a/builders/flight-action-api/config/projects/flight-action-api.rb
+++ b/builders/flight-action-api/config/projects/flight-action-api.rb
@@ -36,7 +36,7 @@ VERSION = '1.4.0'
 override 'flight-action-api', version: VERSION
 
 build_version VERSION
-build_iteration 2
+build_iteration 3
 
 dependency 'preparation'
 dependency 'flight-action-api'

--- a/builders/flight-action-api/package-scripts/flight-action-api/postinst
+++ b/builders/flight-action-api/package-scripts/flight-action-api/postinst
@@ -25,22 +25,61 @@
 # For more information on OpenFlight Omnibus Builder, please visit:
 # https://github.com/openflighthpc/openflight-omnibus-builder
 #===============================================================================
-mkdir -p "${flight_ROOT:-/opt/flight}"/opt/action-api/libexec/
 
-flight service info action-api | while read line; do
-  # Find the jwt_secret line
-  if [ "$(echo "$line" | cut -f2)" == "jwt_secret" ]; then
-    if [ -z "$(echo "$line" | cut -f4)" ]; then
-      # Configure it with a random string if unset
-      secret=$( echo $(hostname --fqdn).$(date  +%s.%N) | sha256sum | cut -c 1-40 )
-      payload="{ \"jwt_secret\": \"$secret\" }"
-    else
-      # Ensure the application is reconfigured even if nothing has changed
-      payload="{}"
+set -e
+export flight_ROOT="${flight_ROOT:-/opt/flight}"
+mkdir -p "$flight_ROOT"/opt/action-api/libexec/
+
+# Determine which version of flight-service is installed
+flight="$flight_ROOT/bin/flight"
+service_version=$("$flight" service --version | grep -oE "[0-9]+\.[0-9]+\.[0-9]+")
+
+# Determine if at least flight service v1.4.0 has been installed
+ruby="$flight_ROOT/bin/ruby"
+is_140=$("$ruby" -e "require 'rubygems'; puts Gem::Version.new('$service_version') >= Gem::Version.new('1.4.0')")
+
+# (Re)configure flight-action
+if [[ "$is_140" == "true" ]]; then
+  "$flight" service info action-api | while read line; do
+    # Find the jwt_secret line
+    if [ "$(echo "$line" | cut -f2)" == "jwt_secret" ]; then
+      if [ -z "$(echo "$line" | cut -f4)" ]; then
+        # Configure it with a random string if unset
+        secret=$( echo $(hostname --fqdn).$(date  +%s.%N) | sha256sum | cut -c 1-40 )
+        payload="{ \"jwt_secret\": \"$secret\" }"
+      else
+        # Ensure the application is reconfigured even if nothing has changed
+        payload="{}"
+      fi
+      echo "$payload" | "$flight" service configure action-api --force --config @- >/dev/null
     fi
-    echo "$payload" | flight service configure action-api --force --config @- >/dev/null
-  fi
-done
+  done
 
-/opt/flight/bin/flight service reload www 1>/dev/null 2>&1
+# Manually configure the application's config if installed with an older version
+# of flight service.
+#
+# NOTE: This fallback can be removed if a hard version dependency is added on
+#       flight-service 1.4.0
+else
+  config_file="$flight_ROOT"/var/lib/service/action-api.yml
+
+  # Read the existing shared secret
+  if [ -f "${config_file}" ]; then
+    secret=$("$ruby" -e "require 'yaml'; puts YAML.load(File.read('$config_file'), symbolize_names: true)[:jwt_secret]")
+
+  # Generate a new shared-secret file
+  else
+    mkdir -p "$(dirname "${config_file}")"
+    secret=$( echo $(hostname --fqdn).$(date  +%s) | md5sum | cut -f1 -d' ')
+    cat <<EOF > "${config_file}"
+---
+jwt_secret: ${secret}
+EOF
+  fi
+
+  # Force the application to be reconfigured
+  /bin/bash "$flight_ROOT"/etc/service/types/action-api/configure.sh jwt_secret="${secret}" 1>/dev/null 2>&1
+fi
+
+"$flight" service reload www 1>/dev/null 2>&1
 exit 0

--- a/builders/flight-action-api/package-scripts/flight-action-api/postinst
+++ b/builders/flight-action-api/package-scripts/flight-action-api/postinst
@@ -27,25 +27,20 @@
 #===============================================================================
 mkdir -p "${flight_ROOT:-/opt/flight}"/opt/action-api/libexec/
 
-# The application needs an authentication secret which can be used to "sign"
-# the JWT tokens it creates.  This needs to be globally uniq, but otherwise
-# has no particular format.
-#
-# Unfortunately, `flight service configure SERVICE` does not have a
-# non-interactive mode.  We do our best to emulate such a thing here. 
-#
-config_file="${flight_ROOT:-/opt/flight}"/var/lib/service/action-api.yml
-if [ ! -f "${config_file}" ]; then
-    mkdir -p "$(dirname "${config_file}")"
-    secret=$( echo $(hostname --fqdn).$(date  +%s) | md5sum | cut -f1 -d' ')
-    cat <<EOF > "${config_file}"
----
-jwt_secret: ${secret}
-EOF
-    flight_ROOT="${flight_ROOT:-/opt/flight}" /bin/bash \
-        "${flight_ROOT:-/opt/flight}"/etc/service/types/action-api/configure.sh \
-        jwt_secret="${secret}"
-fi
+flight service info action-api | while read line; do
+  # Find the jwt_secret line
+  if [ "$(echo "$line" | cut -f2)" == "jwt_secret" ]; then
+    if [ -z "$(echo "$line" | cut -f4)" ]; then
+      # Configure it with a random string if unset
+      secret=$( echo $(hostname --fqdn).$(date  +%s.%N) | sha256sum | cut -c 1-40 )
+      payload="{ \"jwt_secret\": \"$secret\" }"
+    else
+      # Ensure the application is reconfigured even if nothing has changed
+      payload="{}"
+    fi
+    echo "$payload" | flight service configure action-api --force --config @- >/dev/null
+  fi
+done
 
 /opt/flight/bin/flight service reload www 1>/dev/null 2>&1
 exit 0

--- a/builders/flight-action-api/package-scripts/flight-action-api/postinst
+++ b/builders/flight-action-api/package-scripts/flight-action-api/postinst
@@ -26,7 +26,6 @@
 # https://github.com/openflighthpc/openflight-omnibus-builder
 #===============================================================================
 
-set -e
 export flight_ROOT="${flight_ROOT:-/opt/flight}"
 mkdir -p "$flight_ROOT"/opt/action-api/libexec/
 


### PR DESCRIPTION
The `jwt_secret` is now set using the non-interactive version of `flight service configure`.

The old value is respected if it has been already set. However the configure script is always ran so it can update the internal `action-api` config.