### PR TITLE
Fix configuring www https port

### DIFF
--- a/builders/flight-console-api/opt/flight/etc/www/server-https.d/console-01-api.conf
+++ b/builders/flight-console-api/opt/flight/etc/www/server-https.d/console-01-api.conf
@@ -32,4 +32,5 @@ location ^~ /console/api/ {
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header X-Forwarded-Proto $scheme;
   proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header X-Real-Port $port;
 }

--- a/builders/flight-console-api/opt/flight/etc/www/server-https.d/console-01-api.conf
+++ b/builders/flight-console-api/opt/flight/etc/www/server-https.d/console-01-api.conf
@@ -32,5 +32,5 @@ location ^~ /console/api/ {
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header X-Forwarded-Proto $scheme;
   proxy_set_header X-Real-IP $remote_addr;
-  proxy_set_header X-Real-Port $port;
+  proxy_set_header X-Real-Port $server_port;
 }

--- a/builders/flight-desktop-restapi/opt/flight/etc/www/server-https.d/flight-desktop.conf
+++ b/builders/flight-desktop-restapi/opt/flight/etc/www/server-https.d/flight-desktop.conf
@@ -32,5 +32,5 @@ location ^~ /desktop/api/ {
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header X-Forwarded-Proto $scheme;
   proxy_set_header X-Real-IP $remote_addr;
-  proxy_set_header X-Real-Port $port;
+  proxy_set_header X-Real-Port $server_port;
 }

--- a/builders/flight-desktop-restapi/opt/flight/etc/www/server-https.d/flight-desktop.conf
+++ b/builders/flight-desktop-restapi/opt/flight/etc/www/server-https.d/flight-desktop.conf
@@ -32,4 +32,5 @@ location ^~ /desktop/api/ {
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header X-Forwarded-Proto $scheme;
   proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header X-Real-Port $port;
 }

--- a/builders/flight-file-manager-api/opt/flight/etc/www/server-https.d/file-manager-api.conf
+++ b/builders/flight-file-manager-api/opt/flight/etc/www/server-https.d/file-manager-api.conf
@@ -32,7 +32,7 @@ location ^~ /files/api/ {
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header X-Forwarded-Proto $scheme;
   proxy_set_header X-Real-IP $remote_addr;
-  proxy_set_header X-Real-Port $port;
+  proxy_set_header X-Real-Port $server_port;
 }
 
 location ^~ /files/backend/ {
@@ -43,5 +43,5 @@ location ^~ /files/backend/ {
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header X-Forwarded-Proto $scheme;
   proxy_set_header X-Real-IP $remote_addr;
-  proxy_set_header X-Real-Port $port;
+  proxy_set_header X-Real-Port $server_port;
 }

--- a/builders/flight-file-manager-api/opt/flight/etc/www/server-https.d/file-manager-api.conf
+++ b/builders/flight-file-manager-api/opt/flight/etc/www/server-https.d/file-manager-api.conf
@@ -32,6 +32,7 @@ location ^~ /files/api/ {
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header X-Forwarded-Proto $scheme;
   proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header X-Real-Port $port;
 }
 
 location ^~ /files/backend/ {
@@ -42,4 +43,5 @@ location ^~ /files/backend/ {
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header X-Forwarded-Proto $scheme;
   proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header X-Real-Port $port;
 }

--- a/builders/flight-job-script-api/opt/flight/etc/www/server-https.d/job-script-api.conf
+++ b/builders/flight-job-script-api/opt/flight/etc/www/server-https.d/job-script-api.conf
@@ -32,5 +32,5 @@ location ^~ /job-scripts/api/ {
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header X-Forwarded-Proto $scheme;
   proxy_set_header X-Real-IP $remote_addr;
-  proxy_set_header X-Real-Port $port;
+  proxy_set_header X-Real-Port $server_port;
 }

--- a/builders/flight-job-script-api/opt/flight/etc/www/server-https.d/job-script-api.conf
+++ b/builders/flight-job-script-api/opt/flight/etc/www/server-https.d/job-script-api.conf
@@ -32,4 +32,5 @@ location ^~ /job-scripts/api/ {
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header X-Forwarded-Proto $scheme;
   proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header X-Real-Port $port;
 }

--- a/builders/flight-login-api/opt/flight/etc/www/server-https.d/login-api.conf
+++ b/builders/flight-login-api/opt/flight/etc/www/server-https.d/login-api.conf
@@ -32,4 +32,5 @@ location ^~ /login/api/ {
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header X-Forwarded-Proto $scheme;
   proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header X-Real-Port $port;
 }

--- a/builders/flight-login-api/opt/flight/etc/www/server-https.d/login-api.conf
+++ b/builders/flight-login-api/opt/flight/etc/www/server-https.d/login-api.conf
@@ -32,5 +32,5 @@ location ^~ /login/api/ {
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header X-Forwarded-Proto $scheme;
   proxy_set_header X-Real-IP $remote_addr;
-  proxy_set_header X-Real-Port $port;
+  proxy_set_header X-Real-Port $server_port;
 }

--- a/builders/flight-www/config/projects/flight-www.rb
+++ b/builders/flight-www/config/projects/flight-www.rb
@@ -39,7 +39,7 @@ override :nginx, version: '1.14.2'
 override 'flight-landing-page', version: '1.2.2'
 
 build_version VERSION
-build_iteration '3'
+build_iteration '4'
 
 dependency 'preparation'
 dependency 'flight-www'

--- a/builders/flight-www/opt/flight/etc/service/types/www/configure.sh
+++ b/builders/flight-www/opt/flight/etc/service/types/www/configure.sh
@@ -14,11 +14,19 @@ for a in "$@"; do
     https_port)
       if [ -f "${flight_ROOT}"/etc/www/http.d/https.conf.disabled ] ; then
           sed -i "${flight_ROOT}"/etc/www/http.d/https.conf.disabled \
-              -e "s/^\s*listen\s.*;/listen ${v} ssl default;/g"
+              -e "s/^\s*listen\s.*;/listen ${v:-443} ssl default;/g"
       fi
       if [ -f "${flight_ROOT}"/etc/www/http.d/https.conf ] ; then
           sed -i "${flight_ROOT}"/etc/www/http.d/https.conf \
-              -e "s/^\s*listen\s.*;/listen ${v} ssl default;/g"
+              -e "s/^\s*listen\s.*;/listen ${v:-443} ssl default;/g"
+      fi
+      if [ -f "${flight_ROOT}"/etc/www/server-http.d/redirect-http-to-https.conf.disabled ] ; then
+          sed -i "${flight_ROOT}"/etc/www/server-http.d/redirect-http-to-https.conf.disabled \
+              -e "s,^\s*return 307 https://\$host.*\$request_uri.*;,return 307 https://\$host:${v}\$request_uri;,g"
+      fi
+      if [ -f "${flight_ROOT}"/etc/www/server-http.d/redirect-http-to-https.conf ] ; then
+          sed -i "${flight_ROOT}"/etc/www/server-http.d/redirect-http-to-https.conf \
+              -e "s,^\s*return 307 https://\$host.*\$request_uri.*;,return 307 https://\$host:${v}\$request_uri;,g"
       fi
     ;;
     *)


### PR DESCRIPTION
Previously, it was possible to configure the HTTPS port used by Flight WWW.  However, using a port other than `443`broke our web suite.

* Redirecting from HTTP - > HTTPS always redirected to `443`.
* Flight File Manager API always tried to connect to the cloudcmd backend on port `443` as Sinatra's `request.port` was not detecting the correct port.  Flight WWW now adds a custom header to allow us to work around that.

These are both now fixed.

New builds of `flight-www` and `flight-file-manager-api` are required.  The other apps have had the fix applied, but as they didn't exhibit the bug do not require a new release.