### PR TITLE
Add a nginx location to download files

### DIFF
--- a/builders/flight-headnode-landing-page/Gemfile
+++ b/builders/flight-headnode-landing-page/Gemfile
@@ -28,3 +28,5 @@ source 'https://rubygems.org'
 
 gem 'omnibus', git: 'https://github.com/openflighthpc/omnibus'
 gem 'omnibus-software', github: 'chef/omnibus-software'
+
+gem 'minitar'

--- a/builders/flight-headnode-landing-page/Gemfile.lock
+++ b/builders/flight-headnode-landing-page/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
       ffi-yajl (~> 2.2)
       mixlib-shellout (>= 2.2, < 4.0)
       toml-rb (>= 1, < 3)
+    minitar (0.9)
     mixlib-cli (2.1.6)
     mixlib-config (3.0.6)
       tomlrb
@@ -110,6 +111,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  minitar
   omnibus!
   omnibus-software!
 

--- a/builders/flight-headnode-landing-page/config/projects/flight-headnode-landing-page.rb
+++ b/builders/flight-headnode-landing-page/config/projects/flight-headnode-landing-page.rb
@@ -31,7 +31,7 @@ friendly_name 'Headnode content for landing page'
 
 install_dir '/opt/flight/opt/www/landing-page/default'
 
-VERSION = '1.3.0-b2'
+VERSION = '1.3.0-b4'
 override 'flight-headnode-landing-page', version: VERSION
 
 build_version VERSION

--- a/builders/flight-headnode-landing-page/config/projects/flight-headnode-landing-page.rb
+++ b/builders/flight-headnode-landing-page/config/projects/flight-headnode-landing-page.rb
@@ -31,7 +31,7 @@ friendly_name 'Headnode content for landing page'
 
 install_dir '/opt/flight/opt/www/landing-page/default'
 
-VERSION = '1.3.0-b1'
+VERSION = '1.3.0-b2'
 override 'flight-headnode-landing-page', version: VERSION
 
 build_version VERSION

--- a/builders/flight-headnode-landing-page/config/projects/flight-headnode-landing-page.rb
+++ b/builders/flight-headnode-landing-page/config/projects/flight-headnode-landing-page.rb
@@ -31,11 +31,11 @@ friendly_name 'Headnode content for landing page'
 
 install_dir '/opt/flight/opt/www/landing-page/default'
 
-VERSION = '1.2.1'
+VERSION = '1.3.0-b1'
 override 'flight-headnode-landing-page', version: VERSION
 
 build_version VERSION
-build_iteration '2'
+build_iteration '1'
 
 dependency 'preparation'
 dependency 'flight-headnode-landing-page'
@@ -58,7 +58,7 @@ exclude '**/.git'
 exclude '**/.gitkeep'
 exclude '**/bundler/git'
 
-runtime_dependency 'flight-landing-page-system-1.0'
+runtime_dependency 'flight-landing-page-system-1.1'
 BRANDING_SYSTEM = '1.0'
 
 package :rpm do

--- a/builders/flight-headnode-landing-page/package-scripts/flight-headnode-landing-page/postinst
+++ b/builders/flight-headnode-landing-page/package-scripts/flight-headnode-landing-page/postinst
@@ -26,6 +26,17 @@
 # https://github.com/openflighthpc/openflight-omnibus-builder
 #===============================================================================
 
+# Checks if the example config pack has been previously installed
+# and symlinks it into place if required
+dir=/opt/flight/opt/www/landing-page/default/content/config-packs/
+flag="$dir/.example-installed"
+if [ ! -f "$flag" ]; then
+  touch "$flag"
+  pushd "$dir" >/dev/null
+  ln -s example.md.disabled example.md
+  popd >/dev/null
+fi
+
 # `flight-www` may not be installed yet.  That is fine, as `flight-www` will
 # compile the landing page once it is installed.
 if [ -f /opt/flight/libexec/commands/landing-page ]; then

--- a/builders/flight-www/config/projects/flight-www.rb
+++ b/builders/flight-www/config/projects/flight-www.rb
@@ -36,7 +36,7 @@ CERT_VERSION = '0.4.5'
 override 'flight-www', version: VERSION
 override 'flight-cert', version: CERT_VERSION
 override :nginx, version: '1.14.2'
-override 'flight-landing-page', version: '1.3.0-b1'
+override 'flight-landing-page', version: '1.3.0-b2'
 
 build_version VERSION
 build_iteration '2'

--- a/builders/flight-www/config/projects/flight-www.rb
+++ b/builders/flight-www/config/projects/flight-www.rb
@@ -31,12 +31,12 @@ friendly_name 'Flight web server service'
 
 install_dir '/opt/flight/opt/www'
 
-VERSION = '1.6.0-b1'
+VERSION = '1.6.0-b2'
 CERT_VERSION = '0.4.5'
 override 'flight-www', version: VERSION
 override 'flight-cert', version: CERT_VERSION
 override :nginx, version: '1.14.2'
-override 'flight-landing-page', version: '1.3.0-b2'
+override 'flight-landing-page', version: '1.3.0-b4'
 
 build_version VERSION
 build_iteration '2'

--- a/builders/flight-www/config/projects/flight-www.rb
+++ b/builders/flight-www/config/projects/flight-www.rb
@@ -31,12 +31,12 @@ friendly_name 'Flight web server service'
 
 install_dir '/opt/flight/opt/www'
 
-VERSION = '1.5.0'
+VERSION = '1.6.0-b1'
 CERT_VERSION = '0.4.5'
 override 'flight-www', version: VERSION
 override 'flight-cert', version: CERT_VERSION
 override :nginx, version: '1.14.2'
-override 'flight-landing-page', version: '1.2.2'
+override 'flight-landing-page', version: '1.3.0-b1'
 
 build_version VERSION
 build_iteration '2'
@@ -58,8 +58,12 @@ exclude '**/.git'
 exclude '**/.gitkeep'
 exclude '**/bundler/git'
 
-WWW_SYSTEM = '1.0'
-LANDING_PAGE_SYSTEM = '1.0'
+# NOTE: The 1.1 system adds the /downloads location
+WWW_SYSTEMS = (0..1).map { |i| ":flight-www-system-1.#{i}" }.join(' ')
+
+# NOTE: The 1.1 system adds config-packs
+LANDING_PAGE_SYSTEMS = (0..1).map { |i| ":flight-landing-page-system-1.#{i}" }.join(' ')
+
 runtime_dependency 'flight-plugin-cron'
 runtime_dependency 'flight-runway'
 runtime_dependency 'flight-ruby-system-2.0'
@@ -87,7 +91,7 @@ package :rpm do
   vendor 'Alces Flight Ltd'
   # repurposed 'priority' field to set RPM recommends/provides
   # provides are prefixed with `:`
-  priority ":flight-www-system-#{WWW_SYSTEM} :flight-landing-page-system-#{LANDING_PAGE_SYSTEM}"
+  priority "#{WWW_SYSTEMS} #{LANDING_PAGE_SYSTEMS}"
 end
 
 package :deb do
@@ -95,5 +99,5 @@ package :deb do
   # repurposed 'section' field to set DEB recommends/provides
   # entire section is prefixed with `:` to trigger handling
   # provides are further prefixed with `:`
-  section "::flight-www-system-#{WWW_SYSTEM} :flight-landing-page-system-#{LANDING_PAGE_SYSTEM}"
+  section ":#{WWW_SYSTEMS} #{LANDING_PAGE_SYSTEMS}"
 end

--- a/builders/flight-www/dist/nginx.conf.tpl
+++ b/builders/flight-www/dist/nginx.conf.tpl
@@ -8,6 +8,7 @@ events {
 }
 
 http {
+    include /opt/flight/opt/www/embedded/conf/mime.types;
     include /opt/flight/etc/www/mime.types;
     default_type application/octet-stream;
     log_format main '$remote_addr - $remote_user [$time_local] "$request" '

--- a/builders/flight-www/dist/nginx.conf.tpl
+++ b/builders/flight-www/dist/nginx.conf.tpl
@@ -8,7 +8,7 @@ events {
 }
 
 http {
-    include /opt/flight/opt/www/embedded/conf/mime.types;
+    include /opt/flight/etc/www/mime.types;
     default_type application/octet-stream;
     log_format main '$remote_addr - $remote_user [$time_local] "$request" '
                     '$status $body_bytes_sent "$http_referer" '

--- a/builders/flight-www/opt/flight/etc/www/mime.types
+++ b/builders/flight-www/opt/flight/etc/www/mime.types
@@ -1,0 +1,127 @@
+# This file has been adapted from:
+# https://raw.githubusercontent.com/nginx/nginx/130a3ec5010227ca93498a1eb3a182062daeb349/conf/mime.types
+#
+# Copyright (C) 2002-2021 Igor Sysoev
+# Copyright (C) 2011-2021 Nginx, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+
+types {
+    text/markdown                                    md;
+
+    text/html                                        html htm shtml;
+    text/css                                         cs;
+    text/xml                                         xml;
+    image/gif                                        gif;
+    image/jpeg                                       jpeg jpg;
+    application/javascript                           js;
+    application/atom+xml                             atom;
+    application/rss+xml                              rss;
+
+    text/mathml                                      mml;
+    text/plain                                       txt;
+    text/vnd.sun.j2me.app-descriptor                 jad;
+    text/vnd.wap.wml                                 wml;
+    text/x-component                                 htc;
+
+    image/png                                        png;
+    image/svg+xml                                    svg svgz;
+    image/tiff                                       tif tiff;
+    image/vnd.wap.wbmp                               wbmp;
+    image/webp                                       webp;
+    image/x-icon                                     ico;
+    image/x-jng                                      jng;
+    image/x-ms-bmp                                   bmp;
+
+    font/woff                                        woff;
+    font/woff2                                       woff2;
+
+    application/java-archive                         jar war ear;
+    application/json                                 json;
+    application/mac-binhex40                         hqx;
+    application/msword                               doc;
+    application/pdf                                  pdf;
+    application/postscript                           ps eps ai;
+    application/rtf                                  rtf;
+    application/vnd.apple.mpegurl                    m3u8;
+    application/vnd.google-earth.kml+xml             kml;
+    application/vnd.google-earth.kmz                 kmz;
+    application/vnd.ms-excel                         xls;
+    application/vnd.ms-fontobject                    eot;
+    application/vnd.ms-powerpoint                    ppt;
+    application/vnd.oasis.opendocument.graphics      odg;
+    application/vnd.oasis.opendocument.presentation  odp;
+    application/vnd.oasis.opendocument.spreadsheet   ods;
+    application/vnd.oasis.opendocument.text          odt;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation
+                                                     pptx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+                                                     xlsx;
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document
+                                                     docx;
+    application/vnd.wap.wmlc                         wmlc;
+    application/wasm                                 wasm;
+    application/x-7z-compressed                      7z;
+    application/x-cocoa                              cco;
+    application/x-java-archive-diff                  jardiff;
+    application/x-java-jnlp-file                     jnlp;
+    application/x-makeself                           run;
+    application/x-perl                               pl pm;
+    application/x-pilot                              prc pdb;
+    application/x-rar-compressed                     rar;
+    application/x-redhat-package-manager             rpm;
+    application/x-sea                                sea;
+    application/x-shockwave-flash                    swf;
+    application/x-stuffit                            sit;
+    application/x-tcl                                tcl tk;
+    application/x-x509-ca-cert                       der pem crt;
+    application/x-xpinstall                          xpi;
+    application/xhtml+xml                            xhtml;
+    application/xspf+xml                             xspf;
+    application/zip                                  zip;
+
+    application/octet-stream                         bin exe dll;
+    application/octet-stream                         deb;
+    application/octet-stream                         dmg;
+    application/octet-stream                         iso img;
+    application/octet-stream                         msi msp msm;
+
+    audio/midi                                       mid midi kar;
+    audio/mpeg                                       mp3;
+    audio/ogg                                        ogg;
+    audio/x-m4a                                      m4a;
+    audio/x-realaudio                                ra;
+
+    video/3gpp                                       3gpp 3gp;
+    video/mp2t                                       ts;
+    video/mp4                                        mp4;
+    video/mpeg                                       mpeg mpg;
+    video/quicktime                                  mov;
+    video/webm                                       webm;
+    video/x-flv                                      flv;
+    video/x-m4v                                      m4v;
+    video/x-mng                                      mng;
+    video/x-ms-asf                                   asx asf;
+    video/x-ms-wmv                                   wmv;
+    video/x-msvideo                                  avi;
+}

--- a/builders/flight-www/opt/flight/etc/www/mime.types
+++ b/builders/flight-www/opt/flight/etc/www/mime.types
@@ -30,7 +30,7 @@ types {
     text/markdown                                    md;
 
     text/html                                        html htm shtml;
-    text/css                                         cs;
+    text/css                                         css;
     text/xml                                         xml;
     image/gif                                        gif;
     image/jpeg                                       jpeg jpg;

--- a/builders/flight-www/opt/flight/etc/www/mime.types
+++ b/builders/flight-www/opt/flight/etc/www/mime.types
@@ -1,127 +1,30 @@
-# This file has been adapted from:
-# https://raw.githubusercontent.com/nginx/nginx/130a3ec5010227ca93498a1eb3a182062daeb349/conf/mime.types
+#==============================================================================
+# Copyright (C) 2021-present Alces Flight Ltd.
 #
-# Copyright (C) 2002-2021 Igor Sysoev
-# Copyright (C) 2011-2021 Nginx, Inc.
-# All rights reserved.
+# This file is part of OpenFlight Omnibus Builder.
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions
-# are met:
-# 1. Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright
-#    notice, this list of conditions and the following disclaimer in the
-#    documentation and/or other materials provided with the distribution.
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
 #
-# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
-# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
-# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-# SUCH DAMAGE.
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on OpenFlight Omnibus Builder, please visit:
+# https://github.com/openflighthpc/openflight-omnibus-builder
+#===============================================================================
 
 types {
-    text/markdown                                    md;
-
-    text/html                                        html htm shtml;
-    text/css                                         css;
-    text/xml                                         xml;
-    image/gif                                        gif;
-    image/jpeg                                       jpeg jpg;
-    application/javascript                           js;
-    application/atom+xml                             atom;
-    application/rss+xml                              rss;
-
-    text/mathml                                      mml;
-    text/plain                                       txt;
-    text/vnd.sun.j2me.app-descriptor                 jad;
-    text/vnd.wap.wml                                 wml;
-    text/x-component                                 htc;
-
-    image/png                                        png;
-    image/svg+xml                                    svg svgz;
-    image/tiff                                       tif tiff;
-    image/vnd.wap.wbmp                               wbmp;
-    image/webp                                       webp;
-    image/x-icon                                     ico;
-    image/x-jng                                      jng;
-    image/x-ms-bmp                                   bmp;
-
-    font/woff                                        woff;
-    font/woff2                                       woff2;
-
-    application/java-archive                         jar war ear;
-    application/json                                 json;
-    application/mac-binhex40                         hqx;
-    application/msword                               doc;
-    application/pdf                                  pdf;
-    application/postscript                           ps eps ai;
-    application/rtf                                  rtf;
-    application/vnd.apple.mpegurl                    m3u8;
-    application/vnd.google-earth.kml+xml             kml;
-    application/vnd.google-earth.kmz                 kmz;
-    application/vnd.ms-excel                         xls;
-    application/vnd.ms-fontobject                    eot;
-    application/vnd.ms-powerpoint                    ppt;
-    application/vnd.oasis.opendocument.graphics      odg;
-    application/vnd.oasis.opendocument.presentation  odp;
-    application/vnd.oasis.opendocument.spreadsheet   ods;
-    application/vnd.oasis.opendocument.text          odt;
-    application/vnd.openxmlformats-officedocument.presentationml.presentation
-                                                     pptx;
-    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
-                                                     xlsx;
-    application/vnd.openxmlformats-officedocument.wordprocessingml.document
-                                                     docx;
-    application/vnd.wap.wmlc                         wmlc;
-    application/wasm                                 wasm;
-    application/x-7z-compressed                      7z;
-    application/x-cocoa                              cco;
-    application/x-java-archive-diff                  jardiff;
-    application/x-java-jnlp-file                     jnlp;
-    application/x-makeself                           run;
-    application/x-perl                               pl pm;
-    application/x-pilot                              prc pdb;
-    application/x-rar-compressed                     rar;
-    application/x-redhat-package-manager             rpm;
-    application/x-sea                                sea;
-    application/x-shockwave-flash                    swf;
-    application/x-stuffit                            sit;
-    application/x-tcl                                tcl tk;
-    application/x-x509-ca-cert                       der pem crt;
-    application/x-xpinstall                          xpi;
-    application/xhtml+xml                            xhtml;
-    application/xspf+xml                             xspf;
-    application/zip                                  zip;
-
-    application/octet-stream                         bin exe dll;
-    application/octet-stream                         deb;
-    application/octet-stream                         dmg;
-    application/octet-stream                         iso img;
-    application/octet-stream                         msi msp msm;
-
-    audio/midi                                       mid midi kar;
-    audio/mpeg                                       mp3;
-    audio/ogg                                        ogg;
-    audio/x-m4a                                      m4a;
-    audio/x-realaudio                                ra;
-
-    video/3gpp                                       3gpp 3gp;
-    video/mp2t                                       ts;
-    video/mp4                                        mp4;
-    video/mpeg                                       mpeg mpg;
-    video/quicktime                                  mov;
-    video/webm                                       webm;
-    video/x-flv                                      flv;
-    video/x-m4v                                      m4v;
-    video/x-mng                                      mng;
-    video/x-ms-asf                                   asx asf;
-    video/x-ms-wmv                                   wmv;
-    video/x-msvideo                                  avi;
+  text/markdown md;
 }

--- a/builders/flight-www/opt/flight/etc/www/server-https.d/downloads.conf
+++ b/builders/flight-www/opt/flight/etc/www/server-https.d/downloads.conf
@@ -1,5 +1,5 @@
-location ~ ^/downloads/(.*)([^/]*)$ {
+location ~ ^/downloads/(.*/)?(.*)$ {
   root /opt/flight/usr/share/www/downloads;
-  add_header Content-disposition "attachment; filename=$2";
+  add_header Content-Disposition "attachment; filename=$2";
   try_files /$1$2 =404;
 }

--- a/builders/flight-www/opt/flight/etc/www/server-https.d/downloads.conf
+++ b/builders/flight-www/opt/flight/etc/www/server-https.d/downloads.conf
@@ -1,0 +1,5 @@
+location ~ ^/downloads/(.*)([^/]*)$ {
+  root /opt/flight/usr/share/www/downloads;
+  add_header Content-disposition "attachment; filename=$2";
+  try_files /$1$2 =404;
+}


### PR DESCRIPTION
A new `/downloads` route has been added to `nginx` which serves file with `Content-Disposition: attachment`.

It also packages the landing page with support for `config-packs`. The files to be downloaded for each config pack should be stored as:
`/opt/flight/usr/share/www/config-packs/<pack-name>/<filename>`

The MIME type/`Content-Type` is inferred from the file extension. By default, `nginx` does not support `text/markdown`. Instead the `mime.type` file has been duplicated into `/opt/flight/etc/www` with the new entry markdown entry.

As the `/downloads` route is a new feature, the system versions have been bumped to `-system-1.1`. The packages still provide the old `-system-1.0` for backwards compatibility.