### PR TITLE
Specify the absolute flexec path in flight-desktop

### DIFF
--- a/builders/flight-desktop/config/projects/flight-desktop.rb
+++ b/builders/flight-desktop/config/projects/flight-desktop.rb
@@ -35,7 +35,7 @@ VERSION = '1.5.0-rc1'
 override 'flight-desktop', version: VERSION
 
 build_version VERSION
-build_iteration 1
+build_iteration 2
 
 dependency 'preparation'
 dependency 'flight-desktop'

--- a/builders/flight-desktop/opt/flight/libexec/commands/desktop
+++ b/builders/flight-desktop/opt/flight/libexec/commands/desktop
@@ -29,7 +29,11 @@
 # For more information on Flight Desktop, please visit:
 # https://github.com/alces-flight/flight-desktop
 # ==============================================================================
+
+flight_ROOT=${flight_ROOT:-"$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." &> /dev/null && pwd )"}
+
 export FLIGHT_CWD=$(pwd)
-cd /opt/flight/opt/desktop
 export FLIGHT_PROGRAM_NAME="${flight_NAME} $(basename $0)"
-flexec bundle exec bin/desktop "$@"
+
+cd /opt/flight/opt/desktop
+"$flight_ROOT"/bin/flexec bundle exec bin/desktop "$@"


### PR DESCRIPTION
This allows it to be ran within a minimal `flight-desktop-restapi` environment.