### PR TITLE
Update file-manager-api and login-api to use the new configuration mechanism

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VAGRANT_SYNCED_FOLDER_OPTIONS='{ "type": "nfs", "mount_options": ["vers=3,tcp"] }'

--- a/builders/flight-file-manager-api/config/projects/flight-file-manager-api.rb
+++ b/builders/flight-file-manager-api/config/projects/flight-file-manager-api.rb
@@ -32,10 +32,10 @@ friendly_name 'Flight File Manager API'
 install_dir '/opt/flight/opt/file-manager-api'
 
 VERSION = '1.1.0'
-override 'flight-file-manager-api', version: VERSION
-override 'flight-file-manager-backend', version: VERSION
+override 'flight-file-manager-api', version: ENV.fetch('ALPHA', VERSION)
+override 'flight-file-manager-backend', version: ENV.fetch('ALPHA', VERSION)
 
-build_version VERSION
+build_version(ENV.key?('ALPHA') ? VERSION.sub(/(-\w+)?\Z/, '-alpha') : VERSION)
 build_iteration 1
 
 dependency 'preparation'

--- a/builders/flight-file-manager-api/config/projects/flight-file-manager-api.rb
+++ b/builders/flight-file-manager-api/config/projects/flight-file-manager-api.rb
@@ -68,7 +68,7 @@ else
   raise "Unrecognised platform: #{ohai['platform_family']}"
 end
 
-config_file File.join(install_dir, 'etc/flight-file-manager-api.yaml')
+config_file '/opt/flight/etc/file-manager-api.yaml'
 config_file '/opt/flight/etc/service/env/file-manager-api'
 
 require 'find'

--- a/builders/flight-file-manager-api/config/software/flight-file-manager-api.rb
+++ b/builders/flight-file-manager-api/config/software/flight-file-manager-api.rb
@@ -53,7 +53,7 @@ build do
   # XXX: Add an api specific README.md to the upstream sources
   [
     'Gemfile', 'Gemfile.lock', 'bin', 'config',
-    'app', 'lib', 'libexec', 'README.md', 'app.rb', 'config.ru'
+    'app', 'lib', 'README.md', 'app.rb', 'config.ru'
   ].each do |file|
     copy File.join('api', file), File.expand_path("#{install_dir}/#{file}/..")
   end
@@ -77,6 +77,19 @@ build do
 
     # Write the updated config
     File.write(dst, config)
+  end
+  project.extra_package_file dst
+
+  # Move the libexec script into place
+  src = File.join project_dir, 'api/libexec/cloudcmd.sh'
+  dst = '/opt/flight/libexec/file-manager-api/cloudcmd.sh'
+  block do
+    # Remove the existing file
+    FileUtils.mkdir_p File.dirname(dst)
+    FileUtils.rm_f dst
+
+    # Copy the file into place
+    FileUtils.cp src, dst
   end
   project.extra_package_file dst
 

--- a/builders/flight-file-manager-api/config/software/flight-file-manager-api.rb
+++ b/builders/flight-file-manager-api/config/software/flight-file-manager-api.rb
@@ -62,36 +62,36 @@ build do
   copy 'api/etc/file-manager-api.yaml', File.join(install_dir, 'etc/file-manager-api.yaml.reference')
 
   # Move the config into the core location
-  src = File.join project_dir, 'api/etc/file-manager-api.yaml'
-  dst = '/opt/flight/etc/file-manager-api.yaml'
+  src_config = File.join project_dir, 'api/etc/file-manager-api.yaml'
+  dst_config = '/opt/flight/etc/file-manager-api.yaml'
   block do
     # Remove the original config
-    FileUtils.mkdir_p File.dirname(dst)
-    FileUtils.rm_f dst
+    FileUtils.mkdir_p File.dirname(dst_config)
+    FileUtils.rm_f dst_config
 
     # Update the relative path expansion note
-    config = File.read(src).gsub(/#>>path<<.*(\n#.*)*(?=\n#--)/, <<~MSG.chomp)
+    config = File.read(src_config).gsub(/#>>path<<.*(\n#.*)*(?=\n#--)/, <<~MSG.chomp)
       # The path maybe absolute or relative. All relative paths are expanded from:
       # /opt/flight
     MSG
 
     # Write the updated config
-    File.write(dst, config)
+    File.write(dst_config, config)
   end
-  project.extra_package_file dst
+  project.extra_package_file dst_config
 
   # Move the libexec script into place
-  src = File.join project_dir, 'api/libexec/cloudcmd.sh'
-  dst = '/opt/flight/libexec/file-manager-api/cloudcmd.sh'
+  src_libexec = File.join project_dir, 'api/libexec/cloudcmd.sh'
+  dst_libexec = '/opt/flight/libexec/file-manager-api/cloudcmd.sh'
   block do
     # Remove the existing file
-    FileUtils.mkdir_p File.dirname(dst)
-    FileUtils.rm_f dst
+    FileUtils.mkdir_p File.dirname(dst_libexec)
+    FileUtils.rm_f dst_libexec
 
     # Copy the file into place
-    FileUtils.cp src, dst
+    FileUtils.cp src_libexec, dst_libexec
   end
-  project.extra_package_file dst
+  project.extra_package_file dst_libexec
 
   # Installs the gems to the shared `vendor/share`
   flags = [

--- a/builders/flight-file-manager-api/config/software/flight-file-manager-api.rb
+++ b/builders/flight-file-manager-api/config/software/flight-file-manager-api.rb
@@ -58,13 +58,25 @@ build do
     copy File.join('api', file), File.expand_path("#{install_dir}/#{file}/..")
   end
 
+  # Copy the un-modified reference config in place
+  copy 'api/etc/file-manager-api.yaml', File.join(install_dir, 'etc/file-manager-api.yaml.reference')
+
   # Move the config into the core location
   src = File.join project_dir, 'api/etc/file-manager-api.yaml'
   dst = '/opt/flight/etc/file-manager-api.yaml'
   block do
+    # Remove the original config
     FileUtils.mkdir_p File.dirname(dst)
     FileUtils.rm_f dst
-    FileUtils.cp src, dst
+
+    # Update the relative path expansion note
+    config = File.read(src).gsub(/#>>path<<.*(\n#.*)*(?=\n#--)/, <<~MSG.chomp)
+      # The path maybe absolute or relative. All relative paths are expanded from:
+      # /opt/flight
+    MSG
+
+    # Write the updated config
+    File.write(dst, config)
   end
   project.extra_package_file dst
 

--- a/builders/flight-file-manager-api/config/software/flight-file-manager-api.rb
+++ b/builders/flight-file-manager-api/config/software/flight-file-manager-api.rb
@@ -58,9 +58,6 @@ build do
     copy File.join('api', file), File.expand_path("#{install_dir}/#{file}/..")
   end
 
-  # Copy the un-modified reference config in place
-  copy 'api/etc/file-manager-api.yaml', File.join(install_dir, 'etc/file-manager-api.yaml.reference')
-
   # Move the config into the core location
   src_config = File.join project_dir, 'api/etc/file-manager-api.yaml'
   dst_config = '/opt/flight/etc/file-manager-api.yaml'
@@ -69,14 +66,8 @@ build do
     FileUtils.mkdir_p File.dirname(dst_config)
     FileUtils.rm_f dst_config
 
-    # Update the relative path expansion note
-    config = File.read(src_config).gsub(/#>>path<<.*(\n#.*)*(?=\n#--)/, <<~MSG.chomp)
-      # The path maybe absolute or relative. All relative paths are expanded from:
-      # /opt/flight
-    MSG
-
     # Write the updated config
-    File.write(dst_config, config)
+    File.write(dst_config, File.read(src_config))
   end
   project.extra_package_file dst_config
 

--- a/builders/flight-file-manager-api/config/software/flight-file-manager-api.rb
+++ b/builders/flight-file-manager-api/config/software/flight-file-manager-api.rb
@@ -52,23 +52,21 @@ build do
   # Moves the api project into place
   # XXX: Add an api specific README.md to the upstream sources
   [
-    'Gemfile', 'Gemfile.lock', 'bin', 'etc/flight-file-manager-api.yaml', 'config',
+    'Gemfile', 'Gemfile.lock', 'bin', 'config',
     'app', 'lib', 'libexec', 'README.md', 'app.rb', 'config.ru'
   ].each do |file|
     copy File.join('api', file), File.expand_path("#{install_dir}/#{file}/..")
   end
 
-  # Update the config
+  # Move the config into the core location
+  src = File.join project_dir, 'api/etc/file-manager-api.yaml'
+  dst = '/opt/flight/etc/file-manager-api.yaml'
   block do
-    path = File.join(install_dir, 'etc/flight-file-manager-api.yaml')
-    content = [
-      File.read(path),
-      "data_dir: /opt/flight/var/lib/file-manager-api",
-      "shared_secret_path: /opt/flight/etc/shared-secret.conf",
-      ''
-    ].join("\n")
-    File.write path, content
+    FileUtils.mkdir_p File.dirname(dst)
+    FileUtils.rm_f dst
+    FileUtils.cp src, dst
   end
+  project.extra_package_file dst
 
   # Installs the gems to the shared `vendor/share`
   flags = [

--- a/builders/flight-file-manager-api/opt/flight/etc/service/env/file-manager-api
+++ b/builders/flight-file-manager-api/opt/flight/etc/service/env/file-manager-api
@@ -27,5 +27,4 @@
 #===============================================================================
 
 RACK_ENV=production
-flight_FILE_MANAGER_API_log_dir=/opt/flight/var/log/file-manager-api
 PUMA_LOG_FILE=/opt/flight/var/log/file-manager-api/puma.log

--- a/builders/flight-login-api/config/projects/flight-login-api.rb
+++ b/builders/flight-login-api/config/projects/flight-login-api.rb
@@ -71,7 +71,7 @@ runtime_dependency 'flight-www-system-1.0'
 runtime_dependency 'flight-service'
 runtime_dependency 'flight-service-system-1.0'
 
-config_file File.join(install_dir, 'etc/flight-login.yaml')
+config_file '/opt/flight/etc/login-api.yaml'
 config_file '/opt/flight/etc/service/env/login-api'
 
 require 'find'

--- a/builders/flight-login-api/config/projects/flight-login-api.rb
+++ b/builders/flight-login-api/config/projects/flight-login-api.rb
@@ -32,9 +32,9 @@ friendly_name 'Flight Websuite Login API'
 install_dir '/opt/flight/opt/login-api'
 
 VERSION = '1.0.1'
-override 'flight-login-api', version: VERSION
+override 'flight-login-api', version: ENV.fetch('ALPHA', VERSION)
 
-build_version VERSION
+build_version(ENV.key?('ALPHA') ? VERSION.sub(/(-\w+)?\Z/, '-alpha') : VERSION)
 build_iteration 1
 
 dependency 'preparation'

--- a/builders/flight-login-api/config/software/flight-login-api.rb
+++ b/builders/flight-login-api/config/software/flight-login-api.rb
@@ -52,15 +52,15 @@ build do
     copy file, File.expand_path("#{install_dir}/#{file}/..")
   end
 
-  # Update the config
+  # Move the config into the core location
+  src = File.join project_dir, 'etc/login-api.yaml'
+  dst = '/opt/flight/etc/login-api.yaml'
   block do
-    path = File.join(install_dir, 'etc/flight-login.yaml')
-    content = [
-      File.read(path),
-      "shared_secret_path: /opt/flight/etc/shared-secret.conf",
-    ].join("\n")
-    File.write path, content
+    FileUtils.mkdir_p File.dirname(dst)
+    FileUtils.rm_f dst
+    FileUtils.cp src, dst
   end
+  project.extra_package_file dst
 
   # Installs the gems to the shared `vendor/share`
   flags = [

--- a/builders/flight-login-api/config/software/flight-login-api.rb
+++ b/builders/flight-login-api/config/software/flight-login-api.rb
@@ -56,9 +56,18 @@ build do
   src = File.join project_dir, 'etc/login-api.yaml'
   dst = '/opt/flight/etc/login-api.yaml'
   block do
+    # Remove the original config
     FileUtils.mkdir_p File.dirname(dst)
     FileUtils.rm_f dst
-    FileUtils.cp src, dst
+
+    # Update the relative path expansion note
+    config = File.read(src).gsub(/#>>path<<.*(?=#--)/m, <<~MSG)
+      The path maybe absolute or relative. All relative paths are expanded from:
+      /opt/flight
+    MSG
+
+    # Write the updated config
+    File.write(dst, config)
   end
   project.extra_package_file dst
 

--- a/builders/flight-login-api/config/software/flight-login-api.rb
+++ b/builders/flight-login-api/config/software/flight-login-api.rb
@@ -52,9 +52,6 @@ build do
     copy file, File.expand_path("#{install_dir}/#{file}/..")
   end
 
-  # Copy the un-modified reference config in place
-  copy 'etc/login-api.yaml', File.join(install_dir, 'etc/login-api.yaml.reference')
-
   # Move the config into the core location
   src = File.join project_dir, 'etc/login-api.yaml'
   dst = '/opt/flight/etc/login-api.yaml'
@@ -63,14 +60,8 @@ build do
     FileUtils.mkdir_p File.dirname(dst)
     FileUtils.rm_f dst
 
-    # Update the relative path expansion note
-    config = File.read(src).gsub(/#>>path<<.*(\n#.*)*(?=\n#--)/, <<~MSG.chomp)
-      # The path maybe absolute or relative. All relative paths are expanded from:
-      # /opt/flight
-    MSG
-
     # Write the updated config
-    File.write(dst, config)
+    File.write(dst, File.read(src))
   end
   project.extra_package_file dst
 

--- a/builders/flight-login-api/config/software/flight-login-api.rb
+++ b/builders/flight-login-api/config/software/flight-login-api.rb
@@ -52,6 +52,9 @@ build do
     copy file, File.expand_path("#{install_dir}/#{file}/..")
   end
 
+  # Copy the un-modified reference config in place
+  copy 'etc/login-api.yaml', File.join(install_dir, 'etc/login-api.yaml.reference')
+
   # Move the config into the core location
   src = File.join project_dir, 'etc/login-api.yaml'
   dst = '/opt/flight/etc/login-api.yaml'
@@ -61,9 +64,9 @@ build do
     FileUtils.rm_f dst
 
     # Update the relative path expansion note
-    config = File.read(src).gsub(/#>>path<<.*(?=#--)/m, <<~MSG)
-      The path maybe absolute or relative. All relative paths are expanded from:
-      /opt/flight
+    config = File.read(src).gsub(/#>>path<<.*(\n#.*)*(?=\n#--)/, <<~MSG.chomp)
+      # The path maybe absolute or relative. All relative paths are expanded from:
+      # /opt/flight
     MSG
 
     # Write the updated config

--- a/builders/flight-login-api/opt/flight/etc/service/types/login-api/configure.sh
+++ b/builders/flight-login-api/opt/flight/etc/service/types/login-api/configure.sh
@@ -34,10 +34,10 @@ for a in "$@"; do
   IFS="=" read k v <<< "${a}"
   case $k in
     cookieDomain)
-      if cat "$env_file" | grep 'FLIGHT_LOGIN_SSO_COOKIE_DOMAIN' ; then
-        sed -i "s/FLIGHT_LOGIN_SSO_COOKIE_DOMAIN=.*/FLIGHT_LOGIN_SSO_COOKIE_DOMAIN=$v/g" "$env_file"
+      if cat "$env_file" | grep 'flight_LOGIN_API_sso_cookie_domain' ; then
+        sed -i "s/flight_LOGIN_API_sso_cookie_domain=.*/flight_LOGIN_API_sso_cookie_domain=$v/g" "$env_file"
       else
-        echo "FLIGHT_LOGIN_SSO_COOKIE_DOMAIN=$v" >> "$env_file"
+        echo "flight_LOGIN_API_sso_cookie_domain=$v" >> "$env_file"
       fi
       ;;
     *)

--- a/builders/flight-starter/build.sh
+++ b/builders/flight-starter/build.sh
@@ -7,7 +7,7 @@ NOW=2021.4
 NEXT=2021.5
 VERSION=${NOW}.0
 TAG=$(echo "$VERSION" | sed "s/~/-/g")
-REL=1
+REL=2
 
 if [ -f /etc/redhat-release ]; then
   echo "Building RPM package..."

--- a/builders/flight-starter/deb/control.tpl
+++ b/builders/flight-starter/deb/control.tpl
@@ -5,4 +5,5 @@ Priority: optional
 Architecture: all
 Maintainer: OpenFlightHPC Project <flight@openflighthpc.org>
 Description: Profile scripts and infrastructure for activating an OpenFlight HPC environment
-Depends: flight-runway, flight-starter-banner, flight-starter-system-1.0
+Depends: flight-runway, flight-starter-banner, flight-starter-system-1.0,
+  flight-web-suite-utils (>= 1.0.0), flight-web-suite-utils (<< 1.0.0)

--- a/builders/flight-starter/rpm/flight-starter.spec
+++ b/builders/flight-starter/rpm/flight-starter.spec
@@ -14,6 +14,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildArch:      noarch
 Requires:       flight-runway, flight-starter-banner => %{_flight_pkg_now}.0~, flight-starter-banner < %{_flight_pkg_next}.0~, flight-starter-system-1.0
+Requires:       flight-web-suite-utils => 1.0.0~ flight-web-suite-utils < 1.1.0~
 %{?el8:Recommends:    flight-plugin-system-starter}
 
 # Required in the post install script

--- a/builders/flight-web-suite-utils/.bundle/config
+++ b/builders/flight-web-suite-utils/.bundle/config
@@ -1,0 +1,3 @@
+---
+BUNDLE_PATH: "/home/vagrant/openflight-omnibus-builder/vendor"
+BUNDLE_BIN: "bin"

--- a/builders/flight-web-suite-utils/.gitignore
+++ b/builders/flight-web-suite-utils/.gitignore
@@ -1,0 +1,10 @@
+*.gem
+.kitchen/
+.kitchen.local.yml
+pkg/*
+.vagrant
+bin/*
+files/**/cache/
+vendor
+vendor
+local

--- a/builders/flight-web-suite-utils/Gemfile
+++ b/builders/flight-web-suite-utils/Gemfile
@@ -1,0 +1,30 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of OpenFlight Omnibus Builder.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on OpenFlight Omnibus Builder, please visit:
+# https://github.com/openflighthpc/openflight-omnibus-builder
+#===============================================================================
+source 'https://rubygems.org'
+
+gem 'omnibus', '~> 6.0'
+gem 'omnibus-software', github: 'chef/omnibus-software'

--- a/builders/flight-web-suite-utils/Gemfile.lock
+++ b/builders/flight-web-suite-utils/Gemfile.lock
@@ -1,0 +1,111 @@
+GIT
+  remote: https://github.com/chef/omnibus-software.git
+  revision: 379f9c7fe65e867af2b69b28b2ced739526f9842
+  specs:
+    omnibus-software (4.0.0)
+      omnibus (>= 5.6.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    awesome_print (1.8.0)
+    aws-eventstream (1.1.0)
+    aws-partitions (1.357.0)
+    aws-sdk-core (3.104.3)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.239.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.36.0)
+      aws-sdk-core (~> 3, >= 3.99.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.78.0)
+      aws-sdk-core (~> 3, >= 3.104.3)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.2.2)
+      aws-eventstream (~> 1, >= 1.0.2)
+    chef-cleanroom (1.0.2)
+    chef-config (15.13.8)
+      addressable
+      chef-utils (= 15.13.8)
+      fuzzyurl
+      mixlib-config (>= 2.2.12, < 4.0)
+      mixlib-shellout (>= 2.0, < 4.0)
+      tomlrb (~> 1.2)
+    chef-sugar-ng (5.1.11)
+    chef-utils (15.13.8)
+    citrus (3.0.2)
+    ffi (1.13.1)
+    ffi-yajl (2.3.4)
+      libyajl2 (~> 1.2)
+    fuzzyurl (0.9.0)
+    iostruct (0.0.4)
+    ipaddress (0.8.3)
+    jmespath (1.4.0)
+    libyajl2 (1.2.0)
+    license_scout (1.1.9)
+      ffi-yajl (~> 2.2)
+      mixlib-shellout (>= 2.2, < 4.0)
+      toml-rb (>= 1, < 3)
+    mixlib-cli (2.1.6)
+    mixlib-config (3.0.9)
+      tomlrb
+    mixlib-log (3.0.8)
+    mixlib-shellout (3.1.4)
+      chef-utils
+    mixlib-versioning (1.2.12)
+    multipart-post (2.1.1)
+    ohai (15.12.0)
+      chef-config (>= 12.8, < 16)
+      ffi (~> 1.9)
+      ffi-yajl (~> 2.2)
+      ipaddress
+      mixlib-cli (>= 1.7.0)
+      mixlib-config (>= 2.0, < 4.0)
+      mixlib-log (>= 2.0.1, < 4.0)
+      mixlib-shellout (>= 2.0, < 4.0)
+      plist (~> 3.1)
+      systemu (~> 2.6.4)
+      wmi-lite (~> 1.0)
+    omnibus (6.1.9)
+      aws-sdk-s3 (~> 1)
+      chef-cleanroom (~> 1.0)
+      chef-sugar-ng (>= 3.3)
+      ffi-yajl (~> 2.2)
+      license_scout (~> 1.0)
+      mixlib-shellout (>= 2.0, < 4.0)
+      mixlib-versioning
+      ohai (>= 13, < 16)
+      pedump
+      ruby-progressbar (~> 1.7)
+      thor (~> 0.18)
+    pedump (0.6.1)
+      awesome_print
+      iostruct (>= 0.0.4)
+      multipart-post (>= 2.0.0)
+      rainbow
+      zhexdump (>= 0.0.2)
+    plist (3.5.0)
+    public_suffix (4.0.5)
+    rainbow (3.0.0)
+    ruby-progressbar (1.10.1)
+    systemu (2.6.5)
+    thor (0.20.3)
+    toml-rb (2.0.1)
+      citrus (~> 3.0, > 3.0)
+    tomlrb (1.3.0)
+    wmi-lite (1.0.5)
+    zhexdump (0.0.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  omnibus (~> 6.0)
+  omnibus-software!
+
+BUNDLED WITH
+   2.1.4

--- a/builders/flight-web-suite-utils/LICENSE.txt
+++ b/builders/flight-web-suite-utils/LICENSE.txt
@@ -1,0 +1,277 @@
+Eclipse Public License - v 2.0
+
+    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+    PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+    OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+  a) in the case of the initial Contributor, the initial content
+     Distributed under this Agreement, and
+
+  b) in the case of each subsequent Contributor:
+     i) changes to the Program, and
+     ii) additions to the Program;
+  where such changes and/or additions to the Program originate from
+  and are Distributed by that particular Contributor. A Contribution
+  "originates" from a Contributor if it was added to the Program by
+  such Contributor itself or anyone acting on such Contributor's behalf.
+  Contributions do not include changes or additions to the Program that
+  are not Modified Works.
+
+"Contributor" means any person or entity that Distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which
+are necessarily infringed by the use or sale of its Contribution alone
+or when combined with the Program.
+
+"Program" means the Contributions Distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement
+or any Secondary License (as applicable), including Contributors.
+
+"Derivative Works" shall mean any work, whether in Source Code or other
+form, that is based on (or derived from) the Program and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship.
+
+"Modified Works" shall mean any work in Source Code or other form that
+results from an addition to, deletion from, or modification of the
+contents of the Program, including, for purposes of clarity any new file
+in Source Code form that contains any contents of the Program. Modified
+Works shall not include works that contain only declarations,
+interfaces, types, classes, structures, or files of the Program solely
+in each case in order to link to, bind by name, or subclass the Program
+or Modified Works thereof.
+
+"Distribute" means the acts of a) distributing or b) making available
+in any manner that enables the transfer of a copy.
+
+"Source Code" means the form of a Program preferred for making
+modifications, including but not limited to software source code,
+documentation source, and configuration files.
+
+"Secondary License" means either the GNU General Public License,
+Version 2.0, or any later versions of that license, including any
+exceptions or additional permissions as identified by the initial
+Contributor.
+
+2. GRANT OF RIGHTS
+
+  a) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free copyright
+  license to reproduce, prepare Derivative Works of, publicly display,
+  publicly perform, Distribute and sublicense the Contribution of such
+  Contributor, if any, and such Derivative Works.
+
+  b) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free patent
+  license under Licensed Patents to make, use, sell, offer to sell,
+  import and otherwise transfer the Contribution of such Contributor,
+  if any, in Source Code or other form. This patent license shall
+  apply to the combination of the Contribution and the Program if, at
+  the time the Contribution is added by the Contributor, such addition
+  of the Contribution causes such combination to be covered by the
+  Licensed Patents. The patent license shall not apply to any other
+  combinations which include the Contribution. No hardware per se is
+  licensed hereunder.
+
+  c) Recipient understands that although each Contributor grants the
+  licenses to its Contributions set forth herein, no assurances are
+  provided by any Contributor that the Program does not infringe the
+  patent or other intellectual property rights of any other entity.
+  Each Contributor disclaims any liability to Recipient for claims
+  brought by any other entity based on infringement of intellectual
+  property rights or otherwise. As a condition to exercising the
+  rights and licenses granted hereunder, each Recipient hereby
+  assumes sole responsibility to secure any other intellectual
+  property rights needed, if any. For example, if a third party
+  patent license is required to allow Recipient to Distribute the
+  Program, it is Recipient's responsibility to acquire that license
+  before distributing the Program.
+
+  d) Each Contributor represents that to its knowledge it has
+  sufficient copyright rights in its Contribution, if any, to grant
+  the copyright license set forth in this Agreement.
+
+  e) Notwithstanding the terms of any Secondary License, no
+  Contributor makes additional grants to any Recipient (other than
+  those set forth in this Agreement) as a result of such Recipient's
+  receipt of the Program under the terms of a Secondary License
+  (if permitted under the terms of Section 3).
+
+3. REQUIREMENTS
+
+3.1 If a Contributor Distributes the Program in any form, then:
+
+  a) the Program must also be made available as Source Code, in
+  accordance with section 3.2, and the Contributor must accompany
+  the Program with a statement that the Source Code for the Program
+  is available under this Agreement, and informs Recipients how to
+  obtain it in a reasonable manner on or through a medium customarily
+  used for software exchange; and
+
+  b) the Contributor may Distribute the Program under a license
+  different than this Agreement, provided that such license:
+     i) effectively disclaims on behalf of all other Contributors all
+     warranties and conditions, express and implied, including
+     warranties or conditions of title and non-infringement, and
+     implied warranties or conditions of merchantability and fitness
+     for a particular purpose;
+
+     ii) effectively excludes on behalf of all other Contributors all
+     liability for damages, including direct, indirect, special,
+     incidental and consequential damages, such as lost profits;
+
+     iii) does not attempt to limit or alter the recipients' rights
+     in the Source Code under section 3.2; and
+
+     iv) requires any subsequent distribution of the Program by any
+     party to be under a license that satisfies the requirements
+     of this section 3.
+
+3.2 When the Program is Distributed as Source Code:
+
+  a) it must be made available under this Agreement, or if the
+  Program (i) is combined with other material in a separate file or
+  files made available under a Secondary License, and (ii) the initial
+  Contributor attached to the Source Code the notice described in
+  Exhibit A of this Agreement, then the Program may be made available
+  under the terms of such Secondary Licenses, and
+
+  b) a copy of this Agreement must be included with each copy of
+  the Program.
+
+3.3 Contributors may not remove or alter any copyright, patent,
+trademark, attribution notices, disclaimers of warranty, or limitations
+of liability ("notices") contained within the Program from any copy of
+the Program which they Distribute, provided that Contributors may add
+their own appropriate notices.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities
+with respect to end users, business partners and the like. While this
+license is intended to facilitate the commercial use of the Program,
+the Contributor who includes the Program in a commercial product
+offering should do so in a manner which does not create potential
+liability for other Contributors. Therefore, if a Contributor includes
+the Program in a commercial product offering, such Contributor
+("Commercial Contributor") hereby agrees to defend and indemnify every
+other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits
+and other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the Program
+in a commercial product offering. The obligations in this section do not
+apply to any claims or Losses relating to any actual or alleged
+intellectual property infringement. In order to qualify, an Indemnified
+Contributor must: a) promptly notify the Commercial Contributor in
+writing of such claim, and b) allow the Commercial Contributor to control,
+and cooperate with the Commercial Contributor in, the defense and any
+related settlement negotiations. The Indemnified Contributor may
+participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor's responsibility
+alone. Under this section, the Commercial Contributor would have to
+defend claims against the other Contributors related to those performance
+claims and warranties, and if a court requires any other Contributor to
+pay any damages as a result, the Commercial Contributor must pay
+those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS"
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF
+TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all
+risks associated with its exercise of rights under this Agreement,
+including but not limited to the risks and costs of program errors,
+compliance with applicable laws, damage to or loss of data, programs
+or equipment, and unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
+SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
+PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of
+the remainder of the terms of this Agreement, and without further
+action by the parties hereto, such provision shall be reformed to the
+minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that the
+Program itself (excluding combinations of the Program with other software
+or hardware) infringes such Recipient's patent(s), then such Recipient's
+rights granted under Section 2(b) shall terminate as of the date such
+litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it
+fails to comply with any of the material terms or conditions of this
+Agreement and does not cure such failure in a reasonable period of
+time after becoming aware of such noncompliance. If all Recipient's
+rights under this Agreement terminate, Recipient agrees to cease use
+and distribution of the Program as soon as reasonably practicable.
+However, Recipient's obligations under this Agreement and any licenses
+granted by Recipient relating to the Program shall continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement,
+but in order to avoid inconsistency the Agreement is copyrighted and
+may only be modified in the following manner. The Agreement Steward
+reserves the right to publish new versions (including revisions) of
+this Agreement from time to time. No one other than the Agreement
+Steward has the right to modify this Agreement. The Eclipse Foundation
+is the initial Agreement Steward. The Eclipse Foundation may assign the
+responsibility to serve as the Agreement Steward to a suitable separate
+entity. Each new version of the Agreement will be given a distinguishing
+version number. The Program (including Contributions) may always be
+Distributed subject to the version of the Agreement under which it was
+received. In addition, after a new version of the Agreement is published,
+Contributor may elect to Distribute the Program (including its
+Contributions) under the new version.
+
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+receives no rights or licenses to the intellectual property of any
+Contributor under this Agreement, whether expressly, by implication,
+estoppel or otherwise. All rights in the Program not expressly granted
+under this Agreement are reserved. Nothing in this Agreement is intended
+to be enforceable by any entity that is not a Contributor or Recipient.
+No third-party beneficiary rights are created under this Agreement.
+
+Exhibit A - Form of Secondary Licenses Notice
+
+"This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set forth
+in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+version(s), and exceptions or additional permissions here}."
+
+  Simply including a copy of this Agreement, including this Exhibit A
+  is not sufficient to license the Source Code under Secondary Licenses.
+
+  If it is not possible or desirable to put the notice in a particular
+  file, then You may include the notice in a location (such as a LICENSE
+  file in a relevant directory) where a recipient would be likely to
+  look for such a notice.
+
+  You may add additional accurate notices of copyright ownership.

--- a/builders/flight-web-suite-utils/README.md
+++ b/builders/flight-web-suite-utils/README.md
@@ -1,0 +1,80 @@
+flight-web-suite-utils Omnibus project
+===========================
+This project creates full-stack platform-specific packages for
+`flight-web-suite-utils`!
+
+Installation
+------------
+You must have a sane Ruby 2.0.0+ environment with Bundler installed. Ensure all
+the required gems are installed:
+
+```shell
+$ bundle install --binstubs
+```
+
+Usage
+-----
+### Build
+
+You create a platform-specific package using the `build project` command:
+
+```shell
+$ bin/omnibus build flight-web-suite-utils
+```
+
+The platform/architecture type of the package created will match the platform
+where the `build project` command is invoked. For example, running this command
+on a MacBook Pro will generate a Mac OS X package. After the build completes
+packages will be available in the `pkg/` folder.
+
+### Clean
+
+You can clean up all temporary files generated during the build process with
+the `clean` command:
+
+```shell
+$ bin/omnibus clean flight-web-suite-utils
+```
+
+Adding the `--purge` purge option removes __ALL__ files generated during the
+build including the project install directory (`/opt/flight-web-suite-utils`) and
+the package cache directory (`/var/cache/omnibus/pkg`):
+
+```shell
+$ bin/omnibus clean flight-web-suite-utils --purge
+```
+
+### Publish
+
+Omnibus has a built-in mechanism for releasing to a variety of "backends", such
+as Amazon S3. You must set the proper credentials in your `omnibus.rb` config
+file or specify them via the command line.
+
+```shell
+$ bin/omnibus publish path/to/*.deb --backend s3
+```
+
+### Help
+
+Full help for the Omnibus command line interface can be accessed with the
+`help` command:
+
+```shell
+$ bin/omnibus help
+```
+
+Version Manifest
+----------------
+
+Git-based software definitions may specify branches as their
+default_version. In this case, the exact git revision to use will be
+determined at build-time unless a project override (see below) or
+external version manifest is used.  To generate a version manifest use
+the `omnibus manifest` command:
+
+```
+omnibus manifest PROJECT -l warn
+```
+
+This will output a JSON-formatted manifest containing the resolved
+version of every software definition.

--- a/builders/flight-web-suite-utils/config/projects/flight-web-suite-utils.rb
+++ b/builders/flight-web-suite-utils/config/projects/flight-web-suite-utils.rb
@@ -1,0 +1,70 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of OpenFlight Omnibus Builder.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on OpenFlight Omnibus Builder, please visit:
+# https://github.com/openflighthpc/openflight-omnibus-builder
+#===============================================================================
+name 'flight-web-suite-utils'
+maintainer 'Alces Flight Ltd'
+homepage 'https://github.com/openflighthpc/flight-web-suite-utils'
+friendly_name 'Flight Websuite Utils'
+
+install_dir '/opt/flight/opt/web-suite-utils'
+
+VERSION = '1.0.0'
+override 'flight-web-suite-utils', version: VERSION
+
+build_version VERSION
+build_iteration 1
+
+dependency 'preparation'
+dependency 'version-manifest'
+
+license 'EPL-2.0'
+license_file 'LICENSE.txt'
+
+description 'Miscellaneous packages for flight-web-suite'
+
+runtime_dependency 'flight-starter-system-1.0'
+
+exclude '**/.git'
+exclude '**/.gitkeep'
+exclude '**/bundler/git'
+
+# Glob after updating the opt directory
+Dir.glob('opt/**/*')
+   .select { |p| File.file? p }
+   .each { |p| extra_package_file p }
+
+package :rpm do
+  vendor 'Alces Flight Ltd'
+  # repurposed 'priority' field to set RPM recommends/provides
+  # provides are prefixed with `:`
+end
+
+package :deb do
+  vendor 'Alces Flight Ltd'
+  # repurposed 'section' field to set DEB recommends/provides
+  # entire section is prefixed with `:` to trigger handling
+  # provides are further prefixed with `:`
+end

--- a/builders/flight-web-suite-utils/config/projects/flight-web-suite-utils.rb
+++ b/builders/flight-web-suite-utils/config/projects/flight-web-suite-utils.rb
@@ -27,7 +27,7 @@
 name 'flight-web-suite-utils'
 maintainer 'Alces Flight Ltd'
 homepage 'https://github.com/openflighthpc/flight-web-suite-utils'
-friendly_name 'Flight Websuite Utils'
+friendly_name 'Flight Web Suite Utils'
 
 install_dir '/opt/flight/opt/web-suite-utils'
 
@@ -43,7 +43,7 @@ dependency 'version-manifest'
 license 'EPL-2.0'
 license_file 'LICENSE.txt'
 
-description 'Miscellaneous packages for flight-web-suite'
+description 'Miscellaneous utilities for flight-web-suite'
 
 runtime_dependency 'flight-starter-system-1.0'
 

--- a/builders/flight-web-suite-utils/omnibus.rb
+++ b/builders/flight-web-suite-utils/omnibus.rb
@@ -1,0 +1,82 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of OpenFlight Omnibus Builder.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# This project is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with this project. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on OpenFlight Omnibus Builder, please visit:
+# https://github.com/openflighthpc/openflight-omnibus-builder
+#===============================================================================
+#
+# This file is used to configure the flight-core project. It contains
+# some minimal configuration examples for working with Omnibus. For a full list
+# of configurable options, please see the documentation for +omnibus/config.rb+.
+#
+
+# Build internally
+# ------------------------------
+# By default, Omnibus uses system folders (like +/var+ and +/opt+) to build and
+# cache components. If you would to build everything internally, you can
+# uncomment the following options. This will prevent the need for root
+# permissions in most cases.
+#
+# Uncomment this line to change the default base directory to "local"
+# -------------------------------------------------------------------
+base_dir '/home/vagrant/flight-web-suite-utils/local'
+
+append_timestamp false
+#
+# Alternatively you can tune the individual values
+# ------------------------------------------------
+# cache_dir     './local/omnibus/cache'
+# git_cache_dir './local/omnibus/cache/git_cache'
+# source_dir    './local/omnibus/src'
+# build_dir     './local/omnibus/build'
+# package_dir   './local/omnibus/pkg'
+# package_tmp   './local/omnibus/pkg-tmp'
+
+# Disable git caching
+# ------------------------------
+# use_git_caching false
+
+# Enable S3 asset caching
+# ------------------------------
+# use_s3_caching true
+# s3_access_key  ENV['AWS_ACCESS_KEY_ID']
+# s3_secret_key  ENV['AWS_SECRET_ACCESS_KEY']
+# s3_profile     ENV['AWS_S3_PROFILE']
+# s3_bucket      ENV['AWS_S3_BUCKET']
+
+# Customize compiler bits
+# ------------------------------
+# solaris_compiler 'gcc'
+# build_retries 5
+# fetcher_read_timeout 120
+# fetcher_retries 5
+
+# Load additional software
+# ------------------------------
+# software_gems ['omnibus-software', 'my-company-software']
+# local_software_dirs ['/path/to/local/software']
+
+# Windows architecture defaults
+# ------------------------------
+windows_arch   %w{x86 x64}.include?((ENV['OMNIBUS_WINDOWS_ARCH'] || '').downcase) ?
+                 ENV['OMNIBUS_WINDOWS_ARCH'].downcase.to_sym : :x86

--- a/builders/flight-web-suite-utils/opt/flight/etc/flight-config-map.d/web-suite.yaml
+++ b/builders/flight-web-suite-utils/opt/flight/etc/flight-config-map.d/web-suite.yaml
@@ -1,0 +1,4 @@
+web-suite:
+  domain:
+    var: 'flight_WEB_SUITE_domain'
+    file: 'web-suite'

--- a/builders/flight-web-suite-utils/resources/flight-web-suite-utils/deb/control.erb
+++ b/builders/flight-web-suite-utils/resources/flight-web-suite-utils/deb/control.erb
@@ -1,0 +1,55 @@
+Package: <%= name %>
+Version: <%= version %>-<%= iteration %>
+License: <%= license %>
+Vendor: <%= vendor %>
+Architecture: <%= architecture %>
+Maintainer: <%= maintainer  %>
+Installed-Size: <%= installed_size %>
+<% unless dependencies.empty? -%>
+Depends: <%= dependencies.join(', ') %>
+<% end -%>
+<% unless conflicts.empty? -%>
+Conflicts: <%= conflicts.join(', ') %>
+<% end -%>
+<% unless replaces.empty? -%>
+Replaces: <%= replaces.join(', ') %>
+<% end -%>
+Section: <%= section[0] == ':' ? 'misc' : section  %>
+Priority: <%= priority %>
+<%
+if section[0] == ':'
+  provides = []
+  recommends = []
+  section[1..-1].split(' ').each do |name|
+    if name[0] == ':'
+      # this is a 'provides'
+      provides << name[1..-1]
+    else
+      # this is a 'recommends'
+      recommends << name
+    end
+  end
+
+  unless recommends.empty?
+-%>
+Recommends: <%= recommends.join(', ') %>
+<%
+  end
+-%>
+<%
+  unless provides.empty?
+-%>
+Provides: <%= provides.join(', ') %>
+<%
+  end
+-%>
+<%
+end
+-%>
+Homepage: <%= homepage %>
+<% lines = description.split("\n") -%>
+<% firstline, *remainder = lines -%>
+Description: <%= firstline %>
+<% if remainder.any? -%>
+<%= remainder.collect { |l| l =~ /^ *$/ ? " ." : " #{l}" }.join("\n") %>
+<% end -%>

--- a/builders/flight-web-suite-utils/resources/flight-web-suite-utils/rpm/spec.erb
+++ b/builders/flight-web-suite-utils/resources/flight-web-suite-utils/rpm/spec.erb
@@ -1,0 +1,100 @@
+# Disable any shell actions, replace them with simply 'true'
+%define __spec_prep_post true
+%define __spec_prep_pre true
+%define __spec_build_post true
+%define __spec_build_pre true
+%define __spec_install_post true
+%define __spec_install_pre true
+%define __spec_clean_post true
+%define __spec_clean_pre true
+
+# Use md5
+%define _binary_filedigest_algorithm 1
+
+%define _binary_payload <%= compression %>
+
+# Metadata
+Name: <%= name %>
+Version: <%= version %>
+Release: <%= iteration %><%= dist_tag ? dist_tag : '' %>
+Summary:  <%= description.split("\n").first.empty? ? "_" : description.split("\n").first %>
+AutoReqProv: no
+BuildRoot: %buildroot
+Prefix: /
+Group: <%= category %>
+License: <%= license %>
+Vendor: <%= vendor %>
+URL: <%= homepage %>
+Packager: <%= maintainer %>
+<% dependencies.each do |name| -%>
+Requires: <%= name %>
+<% end -%>
+<%
+if priority != 'extra'
+  provides = []
+  recommends = []
+  priority.split(' ').each do |name|
+    if name[0] == ':'
+      # this is a 'provides'
+      provides << name[1..-1]
+    else
+      # this is a 'recommends'
+      recommends << name
+    end
+  end
+
+  unless dist_tag.include? '7'
+    recommends.each do |name|
+-%>
+Recommends: <%= name %>
+<%
+    end
+  end
+-%>
+<%
+  provides.each do |name|
+-%>
+Provides: <%= name %>
+<%
+  end
+-%>
+<%
+end
+-%>
+<% conflicts.each do |name| -%>
+Conflicts: <%= name %>
+<% end -%>
+<% replaces.each do |name| -%>
+Obsoletes: <%= name %>
+<%- end -%>
+<% # RPM rejects descriptions with blank lines (even between content) -%>
+%description
+<%= description.gsub(/^\s*$/, " .") %>
+
+%prep
+# noop
+
+%build
+# noop
+
+%install
+# noop
+
+%clean
+# noop
+
+<% scripts.each do |name, contents| -%>
+%<%= name %>
+<%= contents %>
+<% end -%>
+
+%files
+%defattr(-,<%= user %>,<%= group %>,-)
+<% # Output config files and then regular files -%>
+<% config_files.each do |file| -%>
+%config(noreplace) <%= file %>
+<% end -%>
+<% # List all files -%>
+<% files.each do |file| -%>
+<%= file %>
+<% end -%>

--- a/builders/flight-web-suite/deb/control.tpl
+++ b/builders/flight-web-suite/deb/control.tpl
@@ -16,3 +16,4 @@ Depends:      flight-console-api (>= 2.1.0), flight-console-api (<< 2.2.0),
   flight-job-script-webapp (>= 1.2.0), flight-job-script-webapp (<< 1.3.0),
   flight-www (>= 1.5.0), flight-www (<< 1.6.0),
   flight-headnode-landing-page (<< 1.3.0)
+  flight-web-suite-utils (>= 1.0.0), flight-web-suite-utils (<< 1.0.0)

--- a/builders/flight-web-suite/rpm/flight-web-suite.spec
+++ b/builders/flight-web-suite/rpm/flight-web-suite.spec
@@ -47,6 +47,7 @@ Requires:       flight-job-script-api => 1.2.0~, flight-job-script-api < 1.3.0~
 Requires:       flight-job-script-webapp => 1.2.0~, flight-job-script-webapp < 1.3.0~
 Requires:       flight-www => 1.5.0~, flight-www < 1.6.0~
 Requires:       flight-headnode-landing-page < 1.3.0~
+Requires:       flight-web-suite-utils => 1.0.0~ flight-web-suite-utils < 1.1.0~
 
 %description
 The Flight Web Suite collection of web applications for accessing a HPC environment.

--- a/builders/flight-www/config/projects/flight-www.rb
+++ b/builders/flight-www/config/projects/flight-www.rb
@@ -33,13 +33,18 @@ install_dir '/opt/flight/opt/www'
 
 VERSION = '1.6.0-b2'
 CERT_VERSION = '0.4.5'
+
 override 'flight-www', version: VERSION
-override 'flight-cert', version: CERT_VERSION
+override 'flight-cert', version: ENV.fetch('ALPHA_cert', CERT_VERSION)
 override :nginx, version: '1.14.2'
 override 'flight-landing-page', version: '1.3.0-b4'
 
-build_version VERSION
-build_iteration '2'
+if ENV.key?('ALPHA_cert')
+  build_version VERSION.sub(/(-\w+)?\Z/, '-alpha')
+else
+  build_version VERSION
+end
+build_iteration '3'
 
 dependency 'preparation'
 dependency 'flight-www'

--- a/builders/flight-www/config/projects/flight-www.rb
+++ b/builders/flight-www/config/projects/flight-www.rb
@@ -44,7 +44,7 @@ if ENV.key?('ALPHA_cert')
 else
   build_version VERSION
 end
-build_iteration '3'
+build_iteration '1'
 
 dependency 'preparation'
 dependency 'flight-www'

--- a/builders/flight-www/config/projects/flight-www.rb
+++ b/builders/flight-www/config/projects/flight-www.rb
@@ -47,6 +47,7 @@ end
 build_iteration '1'
 
 dependency 'preparation'
+dependency 'enforce-flight-runway'
 dependency 'flight-www'
 dependency 'flight-landing-page'
 dependency 'flight-cert'

--- a/builders/flight-www/config/software/flight-cert.rb
+++ b/builders/flight-www/config/software/flight-cert.rb
@@ -29,8 +29,6 @@ default_version '0.0.0'
 
 source git: 'https://github.com/openflighthpc/flight-cert'
 
-dependency 'enforce-flight-runway'
-
 license 'EPL-2.0'
 license_file 'LICENSE.txt'
 skip_transitive_dependency_licensing true

--- a/builders/flight-www/package-scripts/flight-www/postinst
+++ b/builders/flight-www/package-scripts/flight-www/postinst
@@ -73,15 +73,22 @@ fi
 
 # Generate a self-signed certificate implicitly
 if [ ! -f "/opt/flight/etc/www/ssl/key.pem" ]; then
-  # Attempt to resolve a domain name
-  # NOTE: This shares error messages with flight-cert
-  domain=$(hostname -d)
-  generated_cert="$?"
-
-  # Attempt to generate a certificate
-  if [ "$generated_cert" -eq "0" ]; then
-    /opt/flight/bin/flight www cert-gen --domain "$domain" --cert-type self-signed >/dev/null 2>&1
+  # Check if flight_WEB_SUITE_domain has been set
+  domain=$(/opt/flight/bin/flight config get web-suite.domain 2>/dev/null)
+  if [ "$?" -eq "0" ] ; then
+    /opt/flight/bin/flight www cert-gen --cert-type self-signed >/dev/null 2>&1
     generated_cert="$?"
+  else
+    # Attempt to resolve a domain name
+    # NOTE: This shares error messages with flight-cert
+    domain=$(hostname -d)
+    generated_cert="$?"
+
+    # Attempt to generate a certificate
+    if [ "$generated_cert" -eq "0" ]; then
+      /opt/flight/bin/flight www cert-gen --domain "$domain" --cert-type self-signed >/dev/null 2>&1
+      generated_cert="$?"
+    fi
   fi
 
   # Attempt to enable-https


### PR DESCRIPTION
EDIT: Original PR description

I need the ability to generate alpha release packages for the `flight-web-suite` domain  changes.

`omnibus` already supports building of branches/commit hashes, so all that is needed is a way to hook in the required value. This means tagging the upstream repo is not required when generating a dev build.

---

In addition to the `alpha` release mechanism, both `login-api` and `file-manager-api` have been updated to use the new `FlightConfiguration::DSL` with a `Flight` stub.

This means the core configuration is now stored within `/opt/flight/etc` and various files within `/opt/flight/{libexec,var}`. Most of the config overrides within the builder have been removed; as they reconfigured the paths to `/opt/flight/...`. This is now done implicitly by the `Flight` stub.

---

The major addition is the "relative path message" within the core configs need to be updated. The original message contains details about `flight_ROOT` and the environment setup. These details are required in the upstream source for documentation purposes, but are needless verbose for the builder.


Once the `builder` has ran, the environment and `flight_ROOT` have been set. The config message should be updated to reflect this:

* The actual configs explicitly state the paths are expanded from `/opt/flight` (because they have to be), and
* An original copy is shipped as `/o/f/o/<app>/etc/<app>.yaml.reference` for in-depth documentation purposes only.

---

A new `flight-web-suite-utils` package has been added. It contains the `flight config` definition for setting the `flight_WEB_SUITE_domain`.