### PR TITLE
Update cacerts software definition

### DIFF
--- a/builders/flight-runway/config/projects/flight-runway.rb
+++ b/builders/flight-runway/config/projects/flight-runway.rb
@@ -35,7 +35,7 @@ VERSION = '1.1.5'
 override 'flight-runway', version: VERSION
 
 build_version VERSION
-build_iteration 1
+build_iteration 2
 
 dependency 'preparation'
 dependency 'flight-runway'

--- a/builders/flight-runway/config/software/cacerts.rb
+++ b/builders/flight-runway/config/software/cacerts.rb
@@ -1,0 +1,47 @@
+#
+# Copyright:: Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "cacerts"
+
+license "MPL-2.0"
+license_file "https://www.mozilla.org/media/MPL/2.0/index.815ca599c9df.txt"
+skip_transitive_dependency_licensing true
+
+default_version "2021-09-30"
+
+source url: "https://curl.se/ca/cacert-#{version}.pem"
+
+# versions_list: https://curl.se/docs/caextract.html
+version("2021-09-30") { source sha256: "f524fc21859b776e18df01a87880efa198112214e13494275dbcbd9bcb71d976" }
+version("2021-07-05") { source sha256: "a3b534269c6974631db35f952e8d7c7dbf3d81ab329a232df575c2661de1214a" }
+version("2021-05-25") { source sha256: "3a32ad57e7f5556e36ede625b854057ac51f996d59e0952c207040077cbe48a9" }
+version("2021-01-19") { source sha256: "e010c0c071a2c79a76aa3c289dc7e4ac4ed38492bfda06d766a80b707ebd2f29" }
+
+relative_path "cacerts-#{version}"
+
+build do
+  mkdir "#{install_dir}/embedded/ssl/certs"
+
+  copy "#{project_dir}/cacert*.pem", "#{install_dir}/embedded/ssl/certs/cacert.pem"
+  copy "#{project_dir}/cacert*.pem", "#{install_dir}/embedded/ssl/cert.pem" if windows?
+
+  # Windows does not support symlinks
+  unless windows?
+    link "certs/cacert.pem", "#{install_dir}/embedded/ssl/cert.pem", unchecked: true
+
+    block { File.chmod(0644, "#{install_dir}/embedded/ssl/certs/cacert.pem") }
+  end
+end


### PR DESCRIPTION
cacerts needs updating to fix an issue with Centos7 detailed at https://blog.devgenius.io/rhel-centos-7-fix-for-lets-encrypt-change-8af2de587fe4 (further details at https://docs.certifytheweb.com/docs/kb/kb-202109-letsencrypt/ and https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/).

The most recent version of the cacerts software definition has been copied from the omnibus-software github repo.  This is sufficient to update cacerts and avoids potentially updating all of the software used in flight-runway.