### PR TITLE
Stop enabling the example config pack during post-installation script

### DIFF
--- a/builders/flight-headnode-landing-page/config/projects/flight-headnode-landing-page.rb
+++ b/builders/flight-headnode-landing-page/config/projects/flight-headnode-landing-page.rb
@@ -35,7 +35,7 @@ VERSION = '1.4.0-rc1'
 override 'flight-headnode-landing-page', version: VERSION
 
 build_version VERSION
-build_iteration 2
+build_iteration 3
 
 dependency 'preparation'
 dependency 'flight-headnode-landing-page'

--- a/builders/flight-headnode-landing-page/package-scripts/flight-headnode-landing-page/postinst
+++ b/builders/flight-headnode-landing-page/package-scripts/flight-headnode-landing-page/postinst
@@ -27,13 +27,15 @@
 #===============================================================================
 
 # Checks if the example config pack has been previously installed
-# and symlinks it into place if required
+# but does not enable it. Uncommenting the `ln -s` call will
+# enable the example config pack.
+
 dir=/opt/flight/opt/www/landing-page/default/content/config-packs/
 flag="$dir/.example-installed"
 if [ ! -f "$flag" ]; then
   touch "$flag"
   pushd "$dir" >/dev/null
-  ln -s example.md.disabled example.md
+  # ln -s example.md.disabled example.md
   popd >/dev/null
 fi
 

--- a/builders/flight-headnode-landing-page/package-scripts/flight-headnode-landing-page/postinst
+++ b/builders/flight-headnode-landing-page/package-scripts/flight-headnode-landing-page/postinst
@@ -26,19 +26,6 @@
 # https://github.com/openflighthpc/openflight-omnibus-builder
 #===============================================================================
 
-# Checks if the example config pack has been previously installed
-# but does not enable it. Uncommenting the `ln -s` call will
-# enable the example config pack.
-
-dir=/opt/flight/opt/www/landing-page/default/content/config-packs/
-flag="$dir/.example-installed"
-if [ ! -f "$flag" ]; then
-  touch "$flag"
-  pushd "$dir" >/dev/null
-  # ln -s example.md.disabled example.md
-  popd >/dev/null
-fi
-
 # `flight-www` may not be installed yet.  That is fine, as `flight-www` will
 # compile the landing page once it is installed.
 if [ -f /opt/flight/libexec/commands/landing-page ]; then


### PR DESCRIPTION
This PR comments out the symbolic link line in the post-installation script which was previously enabling the `example.md.disabled` config pack. It also adjusts the comment above the 'enable' clause describing how to enable it.