### PR TITLE
Describe environment override parameter for flight desktop

### DIFF
--- a/builders/flight-desktop/contrib/howto/1.8
+++ b/builders/flight-desktop/contrib/howto/1.8
@@ -140,6 +140,22 @@ If prompted, you should supply the following password: XXXXXXX
 
 The session is now ready to be accessed with your favourite vnc client.
 
+### Environment options
+
+By default, when starting a session, the session environment is reset, and
+therefore does not keep environment variables from the machine it is started
+from. To override this feature, and carry over environment variables from the
+machine, you can include the following argument at the command line:
+
+~~~
+flight desktop start gnome \
+ --no-env-override
+~~~
+
+This is particularly important when starting interactive desktop sessions from
+Flight Job, as the latter tool sets various environment variables for SLURM and
+other job related packages.
+
 ### Starting Applications
 
 When you start a session you can provide a "post initializtion" script to run

--- a/builders/flight-desktop/contrib/howto/1.8
+++ b/builders/flight-desktop/contrib/howto/1.8
@@ -148,13 +148,20 @@ from. To override this feature, and carry over environment variables from the
 machine, you can include the following argument at the command line:
 
 ~~~
-flight desktop start gnome \
- --no-env-override
+flight desktop start gnome --no-override-env
 ~~~
 
 This is particularly important when starting interactive desktop sessions from
 Flight Job, as the latter tool sets various environment variables for SLURM and
 other job related packages.
+
+The application also supports the inverse functionality. By using the following argument:
+
+~~~
+flight desktop start gnome --override-env
+~~~
+
+The environment is forcefully blanked, regardless of the inclusion of `--no-override-env` or the value given in `config.yml`.
 
 ### Starting Applications
 


### PR DESCRIPTION
This PR updates the `flight-desktop` documentation to describe usage of a new CLI parameter introduced in https://github.com/openflighthpc/flight-desktop/pull/40.