### PR TITLE
Limit file manager api file upload size to 50M

### DIFF
--- a/builders/flight-file-manager-api/config/projects/flight-file-manager-api.rb
+++ b/builders/flight-file-manager-api/config/projects/flight-file-manager-api.rb
@@ -36,7 +36,7 @@ override 'flight-file-manager-api', version: ENV.fetch('ALPHA', VERSION)
 override 'flight-file-manager-backend', version: ENV.fetch('ALPHA', VERSION)
 
 build_version(ENV.key?('ALPHA') ? VERSION.sub(/(-\w+)?\Z/, '-alpha') : VERSION)
-build_iteration 1
+build_iteration 2
 
 dependency 'preparation'
 dependency 'flight-file-manager-api'

--- a/builders/flight-file-manager-api/opt/flight/etc/www/server-https.d/file-manager-api.conf
+++ b/builders/flight-file-manager-api/opt/flight/etc/www/server-https.d/file-manager-api.conf
@@ -44,4 +44,5 @@ location ^~ /files/backend/ {
   proxy_set_header X-Forwarded-Proto $scheme;
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Real-Port $server_port;
+  client_max_body_size 50M;
 }

--- a/builders/flight-www/config/projects/flight-www.rb
+++ b/builders/flight-www/config/projects/flight-www.rb
@@ -44,7 +44,7 @@ if ENV.key?('ALPHA') || ENV.key?('ALPHA_cert')
 else
   build_version VERSION
 end
-build_iteration 1
+build_iteration 2
 
 dependency 'preparation'
 dependency 'enforce-flight-runway'

--- a/builders/flight-www/dist/nginx.conf.tpl
+++ b/builders/flight-www/dist/nginx.conf.tpl
@@ -19,6 +19,6 @@ http {
     #tcp_nopush on;
     keepalive_timeout 65;
     gzip on;
-    error_page 404 /not-found;
+    error_page 404 @not-found;
     include /opt/flight/etc/www/http.d/*.conf;
 }

--- a/builders/flight-www/opt/flight/etc/www/error-locations.conf
+++ b/builders/flight-www/opt/flight/etc/www/error-locations.conf
@@ -1,0 +1,4 @@
+location @not-found {
+  internal;
+  try_files /not-found /not-found/index.html =404;
+}

--- a/builders/flight-www/opt/flight/etc/www/http.d/base-http.conf
+++ b/builders/flight-www/opt/flight/etc/www/http.d/base-http.conf
@@ -1,5 +1,6 @@
 server {
   listen 80 default;
   include /opt/flight/etc/www/server-http.d/*.conf;
+  include /opt/flight/etc/www/error-locations.conf;
   absolute_redirect off;
 }

--- a/builders/flight-www/opt/flight/etc/www/http.d/https.conf.disabled
+++ b/builders/flight-www/opt/flight/etc/www/http.d/https.conf.disabled
@@ -1,4 +1,5 @@
 server {
   listen 443 ssl default;
   include /opt/flight/etc/www/server-https.d/*.conf;
+  include /opt/flight/etc/www/error-locations.conf;
 }


### PR DESCRIPTION
This PR adds a line to an nginx config file under `flight-file-manager-api`. It sets the maximum file upload size to 50MB.