### PR TITLE
Add webapp components login menu to Landing Page

### DIFF
--- a/builders/flight-headnode-landing-page/config/projects/flight-headnode-landing-page.rb
+++ b/builders/flight-headnode-landing-page/config/projects/flight-headnode-landing-page.rb
@@ -32,9 +32,15 @@ friendly_name 'Headnode content for landing page'
 install_dir '/opt/flight/opt/www/landing-page/default'
 
 VERSION = '1.5.0'
-override 'flight-headnode-landing-page', version: VERSION
+LOGIN_VERSION = '0.3.0'
+override 'flight-headnode-landing-page', version: ENV.fetch('ALPHA', VERSION)
+override 'flight-webapp-components', version: ENV.fetch('ALPHA_login', LOGIN_VERSION)
 
-build_version VERSION
+if ENV.key?('ALPHA') || ENV.key?('ALPHA_login')
+  build_version VERSION.sub(/(-\w+)?\Z/, '-alpha')
+else
+  build_version VERSION
+end
 build_iteration 1
 
 dependency 'preparation'

--- a/builders/flight-headnode-landing-page/config/projects/flight-headnode-landing-page.rb
+++ b/builders/flight-headnode-landing-page/config/projects/flight-headnode-landing-page.rb
@@ -39,6 +39,7 @@ build_iteration 1
 
 dependency 'preparation'
 dependency 'flight-headnode-landing-page'
+dependency 'flight-webapp-components'
 dependency 'version-manifest'
 
 if ohai['platform_family'] == 'rhel'

--- a/builders/flight-headnode-landing-page/config/software/enforce-flight-nodejs.rb
+++ b/builders/flight-headnode-landing-page/config/software/enforce-flight-nodejs.rb
@@ -1,0 +1,12 @@
+name "enforce-flight-nodejs"
+description "enforce existence of flight-nodejs"
+default_version "1.0.0"
+
+license :project_license
+skip_transitive_dependency_licensing true
+
+build do
+  block do
+    raise "Flight NodeJS is not installed!" if ! File.exists?('/opt/flight/bin/yarn')
+  end
+end

--- a/builders/flight-headnode-landing-page/config/software/flight-headnode-landing-page.rb
+++ b/builders/flight-headnode-landing-page/config/software/flight-headnode-landing-page.rb
@@ -29,7 +29,7 @@ require 'zlib'
 require 'minitar'
 
 name 'flight-headnode-landing-page'
-default_version 'enh/login-widget'
+default_version '0.0.0'
 
 source git: "https://github.com/openflighthpc/flight-landing-page"
 

--- a/builders/flight-headnode-landing-page/config/software/flight-headnode-landing-page.rb
+++ b/builders/flight-headnode-landing-page/config/software/flight-headnode-landing-page.rb
@@ -29,9 +29,9 @@ require 'zlib'
 require 'minitar'
 
 name 'flight-headnode-landing-page'
-default_version '0.0.0'
+default_version 'enh/login-widget'
 
-source git: 'https://github.com/openflighthpc/flight-landing-page'
+source git: "https://github.com/openflighthpc/flight-landing-page"
 
 license 'EPL-2.0'
 license_file 'LICENSE.txt'
@@ -61,7 +61,6 @@ build do
     end
   end
 
-  # Add the files to the rpm
   project.extra_package_file readme
   project.extra_package_file tarball
 end

--- a/builders/flight-headnode-landing-page/config/software/flight-webapp-components.rb
+++ b/builders/flight-headnode-landing-page/config/software/flight-webapp-components.rb
@@ -13,6 +13,8 @@ skip_transitive_dependency_licensing true
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
+  # Configure the URL used to access the login API.
+  env["REACT_APP_LOGIN_API_BASE_URL"] = "/login/api/v0"
 
   # Build flight-webapp-components and the login menu
   block do

--- a/builders/flight-headnode-landing-page/config/software/flight-webapp-components.rb
+++ b/builders/flight-headnode-landing-page/config/software/flight-webapp-components.rb
@@ -3,7 +3,7 @@ require 'zlib'
 require 'minitar'
 
 name 'flight-webapp-components'
-default_version 'enh/account-menu-builder'
+default_version '0.0.0'
 
 source git: "https://github.com/openflighthpc/flight-webapp-components"
 

--- a/builders/flight-headnode-landing-page/config/software/flight-webapp-components.rb
+++ b/builders/flight-headnode-landing-page/config/software/flight-webapp-components.rb
@@ -1,0 +1,48 @@
+
+require 'zlib'
+require 'minitar'
+
+name 'flight-webapp-components'
+default_version 'enh/account-menu-builder'
+
+source git: "https://github.com/openflighthpc/flight-webapp-components"
+
+dependency 'enforce-flight-nodejs'
+
+skip_transitive_dependency_licensing true
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  # Build flight-webapp-components and the login menu
+  block do
+    # Build flight-webapp-components
+    command "cd #{project_dir} && /opt/flight/bin/yarn install", env: env
+    command "cd #{project_dir} && /opt/flight/bin/yarn run build", env: env
+
+    # Add newly built components to package.json of builder
+    package_path = File.join(project_dir, 'builder', 'package.json')
+    config = JSON.parse(File.read(package_path))
+    config["dependencies"]["flight-webapp-components"] = "link:.."
+    File.write(
+      package_path,
+      config.to_json
+    )
+
+    # Build flight login menu
+    command "cd #{project_dir}/builder && /opt/flight/bin/yarn install", env: env
+    command "cd #{project_dir}/builder && /opt/flight/bin/yarn run build", env: env
+
+    # Move newly generated static js and css files to headnode dir
+    FileUtils.mkdir_p(File.join(install_dir, "content", "js"))
+    command "cp " \
+            "#{project_dir}/builder/build/static/js/main.js " \
+            "#{install_dir}/content/js/login.js"
+    command "cp " \
+            "#{project_dir}/builder/build/static/css/main.css " \
+            "#{install_dir}/content/styles/login.css"
+  end
+
+  # Clean up components dir
+  FileUtils.rm_rf(project_dir)
+end

--- a/builders/flight-headnode-landing-page/config/software/flight-webapp-components.rb
+++ b/builders/flight-headnode-landing-page/config/software/flight-webapp-components.rb
@@ -20,15 +20,6 @@ build do
     command "cd #{project_dir} && /opt/flight/bin/yarn install", env: env
     command "cd #{project_dir} && /opt/flight/bin/yarn run build", env: env
 
-    # Add newly built components to package.json of builder
-    package_path = File.join(project_dir, 'builder', 'package.json')
-    config = JSON.parse(File.read(package_path))
-    config["dependencies"]["flight-webapp-components"] = "link:.."
-    File.write(
-      package_path,
-      config.to_json
-    )
-
     # Build flight login menu
     command "cd #{project_dir}/builder && /opt/flight/bin/yarn install", env: env
     command "cd #{project_dir}/builder && /opt/flight/bin/yarn run build", env: env


### PR DESCRIPTION
This PR is part of a group of PRs which aim to create a static version of the account menu from `flight-webapp-components` and include this static version on `flight-landing-page`.

This PR adds to the `flight-headnode-landing-page` builder to include the newly created account menu build created in https://github.com/openflighthpc/flight-webapp-components/pull/8.

NB: The Github paths used in this PR's Omnibus files refer to feature branches, and will need to be changed to a version number prior to merging.