### PR TITLE
Centos Stream 9 builder

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -63,6 +63,25 @@ Vagrant.configure("2") do |config|
     end
   end
 
+  config.vm.define 'centos9s', autostart: false do |build|
+    build.vm.box = 'generic/centos9s'
+
+    # These _might_ become necessary again in the future.
+    # As of 27-04-2023, they are not.
+    #
+    #build.vbguest.auto_update = false
+    #build.vbguest.installer_hooks[:before_start] = [
+    #  "sudo dnf -y install libXmu libXext libXt libX11",
+    #  #"sudo dnf -y upgrade --refresh",
+    #  "sudo dnf -y install kernel-devel"
+    #]
+
+    build.vm.provision "shell", path: "vagrant/provision.sh"
+    if File.directory?(code_path)
+      build.vm.synced_folder code_path, "/code"
+    end
+  end
+
   config.vm.define "ubuntu1804", autostart: false do |build|
     build.vm.box = 'ubuntu/bionic64'
     build.vm.provision "shell", path: "vagrant/provision.sh"


### PR DESCRIPTION
This PR adds a new build definition to the `Vagrantfile` for use in building packages for the Centos Stream 9 platform.

Work was required to get RVM/Ruby 2.7 working. Ruby 2.7 (and any subsequent use of `rubygems`) depends on OpenSSL 1.1. OpenSSL 1.1 does not exist in the Centos Stream 9 repositories (it ships with OpenSSL 3.0).

The `vagrant/provision.sh` file has had extra steps added to it to:
- Download the OpenSSL 1.1 source
- Compile the source to `/opt/openssl-1.1.1t`
- Link the system SSL certificates to OpenSSL 1.1.1
- Install Ruby 2.7, pointing it at the newly compiled OpenSSL 1.1.1

Once the extra steps are complete, the virtual machine is ready to build packages out of the box.