### PR TITLE
Use different SSH key type in console-api for RH9

### DIFF
--- a/builders/flight-console-api/config/projects/flight-console-api.rb
+++ b/builders/flight-console-api/config/projects/flight-console-api.rb
@@ -35,7 +35,7 @@ VERSION = '2.2.2'
 override 'flight-console-api', version: ENV.fetch('ALPHA', VERSION)
 
 build_version(ENV.key?('ALPHA') ? VERSION.sub(/(-\w+)?\Z/, '-alpha') : VERSION)
-build_iteration 1
+build_iteration 2
 
 dependency 'preparation'
 dependency 'update_web_suite_package_scripts'

--- a/builders/flight-console-api/package-scripts/flight-console-api/postinst
+++ b/builders/flight-console-api/package-scripts/flight-console-api/postinst
@@ -51,7 +51,12 @@ priv_key=${flight_ROOT}/etc/console-api/id_rsa
 pub_key="$priv_key".pub
 if [ ! -f "$priv_key" ]; then
   mkdir -p $(dirname "$priv_key")
-  ssh-keygen -b 4096 -t rsa -f "$priv_key" -q -N "" -C "Flight Console API Key"
+
+  if [ -f /etc/redhat-release ] && ! grep -q 'release 9' /etc/redhat-release; then
+    ssh-keygen -b 521 -t ecdsa -f "$priv_key" -q -N "" -C "Flight Console API Key"
+  else
+    ssh-keygen -b 4096 -t rsa -f "$priv_key" -q -N "" -C "Flight Console API Key"
+  fi
 
   # Ensure any existing public key is removed
   rm -f "$pub_key"


### PR DESCRIPTION
SSH-RSA is deprecated, so we use ECDSA now.