### PR TITLE
Fix Centos 8 mirrors

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,8 +46,22 @@ Vagrant.configure("2") do |config|
     build.vm.box = 'bento/centos-8'
     # Versions greater than this suffer from a "Ruby file operations on NFS
     # mounts" issue.  See https://bugzilla.redhat.com/show_bug.cgi?id=1840284.
+
+    build.vbguest.auto_update = false
+
+    # Centos 8 has now reached EOL and no longer receives development resources
+    # from the official CentOS proect. We should be using the `vault.centos.org`
+    # mirrors instead of the official ones.
+    build.vbguest.installer_hooks[:before_install] =
+      [
+        'cd /etc/yum.repos.d/',
+        "sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*",
+        "sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*"
+      ]
+
     build.vm.box_version = '202010.22.0'
     build.vm.provision "shell", path: "vagrant/provision.sh"
+
     if File.directory?(code_path)
       build.vm.synced_folder code_path, "/code"
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -90,6 +90,8 @@ Vagrant.configure("2") do |config|
     #  "sudo dnf -y install kernel-devel"
     #]
 
+    build.vbguest.auto_update = false
+
     build.vm.provision "shell", path: "vagrant/provision.sh"
     if File.directory?(code_path)
       build.vm.synced_folder code_path, "/code"

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -113,6 +113,14 @@ if [ "$1" != "test" ]; then
   if which yum &>/dev/null; then
     CENTOS_VER=$(rpm --eval '%{centos_ver}')
 
+    if [[ $CENTOS_VER == 8 ]] && ! dnf makecache ; then
+      # Centos 8 has now reached EOL and no longer receives development resources
+      # from the official CentOS proect. We should be using the `vault.centos.org`
+      # mirrors instead of the official ones.
+      sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+      sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+    fi
+
     yum install -y -e0 git rpm-build cmake
     install_rvm
     source /etc/profile.d/rvm.sh


### PR DESCRIPTION
Centos 8 has now reached EOL and no longer receives development resources from the official CentOS proect. We are now using the `vault.centos.org` repos. The logic to switch repos is added both in the provisioning script and in the `vagrant-vbguest` installer hooks, as the latter is executed prior to the provisioning script (but not always executed at all).