### PR TITLE
Flight User Suite plugin dependency

### DIFF
--- a/builders/flight-user-suite/build.sh
+++ b/builders/flight-user-suite/build.sh
@@ -5,7 +5,7 @@ mkdir -p pkg
 
 NAME=flight-user-suite
 VERSION=2023.2
-REL=2
+REL=3
 
 if [ -f /etc/redhat-release ]; then
   echo "Building RPM package..."

--- a/builders/flight-user-suite/deb/control.tpl
+++ b/builders/flight-user-suite/deb/control.tpl
@@ -12,3 +12,4 @@ Depends: flight-runway (>= 1.1.0), flight-runway (<< 1.2.0),
   flight-job (>= 2.10.0), flight-job (<< 2.11.0),
   flight-howto (>= 1.0.2), flight-howto (<< 1.2.0),
   flight-silo (>= 0.2.0), flight-silo (<< 1.0.0)
+Recommends: flight-plugin-system-starter

--- a/builders/flight-user-suite/rpm/flight-user-suite.spec
+++ b/builders/flight-user-suite/rpm/flight-user-suite.spec
@@ -11,7 +11,9 @@ URL:            https://openflighthpc.org
 BuildArch:     noarch
 Requires:      flight-runway => 1.1.0, flight-runway < 1.2.0~
 Requires:      flight-starter => 2023.1.0, flight-starter < 2023.2.0~
-%{?el8:Recommends:    flight-plugin-system-starter}
+%if %{rhel} >= 8
+Recommends:    flight-plugin-system-starter
+%endif
 Requires:      flight-env => 1.5.0, flight-env < 1.6.0~
 Requires:      flight-desktop => 1.11.0, flight-desktop < 1.12.0~
 Requires:      flight-job => 2.10.0, flight-job < 2.11.0~


### PR DESCRIPTION
This PR introduces a weak dependency on `flight-plugin-system-starter` for Flight User Suite on all available platforms (all except EL7). These platforms will now prefer `flight-plugin-system-starter` over `flight-plugin-manual-starter`.