### PR TITLE
Use ECDSA key instead of RSA in Console API

### DIFF
--- a/builders/flight-console-api/config/projects/flight-console-api.rb
+++ b/builders/flight-console-api/config/projects/flight-console-api.rb
@@ -31,11 +31,11 @@ friendly_name 'Flight Console api'
 
 install_dir '/opt/flight/opt/console-api'
 
-VERSION = '2.2.2'
+VERSION = '2.2.3'
 override 'flight-console-api', version: ENV.fetch('ALPHA', VERSION)
 
 build_version(ENV.key?('ALPHA') ? VERSION.sub(/(-\w+)?\Z/, '-alpha') : VERSION)
-build_iteration 3
+build_iteration 1
 
 dependency 'preparation'
 dependency 'update_web_suite_package_scripts'

--- a/builders/flight-console-api/opt/flight/opt/console-api/etc/config.json
+++ b/builders/flight-console-api/opt/flight/opt/console-api/etc/config.json
@@ -9,8 +9,8 @@
     "hosts": [
       { "host": null, "port": 22 }
     ],
-    "public_key_path": "%{flight_ROOT}/etc/console-api/id_rsa.pub",
-    "private_key_path": "%{flight_ROOT}/etc/console-api/id_rsa",
+    "public_key_path": "%{flight_ROOT}/etc/console-api/flight_console_api_key.pub",
+    "private_key_path": "%{flight_ROOT}/etc/console-api/flight_console_api_key",
     "localAddress": null,
     "localPort": null,
     "term": "xterm-color",

--- a/builders/flight-console-api/package-scripts/flight-console-api/postinst
+++ b/builders/flight-console-api/package-scripts/flight-console-api/postinst
@@ -46,17 +46,14 @@ else
     chmod 0400 "${env_file}"
 fi
 
-# Generate a private key if required
-priv_key=${flight_ROOT}/etc/console-api/id_rsa
+priv_key=${flight_ROOT}/etc/console-api/flight_console_api_key
 pub_key="$priv_key".pub
+
+# Generate a private key if required
 if [ ! -f "$priv_key" ]; then
   mkdir -p $(dirname "$priv_key")
 
-  if [ -f /etc/redhat-release ] && grep -q 'release 9' /etc/redhat-release; then
-    ssh-keygen -b 521 -t ecdsa -f "$priv_key" -q -N "" -C "Flight Console API Key"
-  else
-    ssh-keygen -b 4096 -t rsa -f "$priv_key" -q -N "" -C "Flight Console API Key"
-  fi
+  ssh-keygen -b 521 -t ecdsa -f "$priv_key" -q -N "" -C "Flight Console API Key"
 
   # Ensure any existing public key is removed
   rm -f "$pub_key"

--- a/builders/flight-console-api/package-scripts/flight-console-api/stubs/postinst-configure
+++ b/builders/flight-console-api/package-scripts/flight-console-api/stubs/postinst-configure
@@ -11,17 +11,14 @@ else
     chmod 0400 "${env_file}"
 fi
 
-# Generate a private key if required
-priv_key=${flight_ROOT}/etc/console-api/id_rsa
+priv_key=${flight_ROOT}/etc/console-api/flight_console_api_key
 pub_key="$priv_key".pub
+
+# Generate a private key if required
 if [ ! -f "$priv_key" ]; then
   mkdir -p $(dirname "$priv_key")
 
-  if [ -f /etc/redhat-release ] && grep -q 'release 9' /etc/redhat-release; then
-    ssh-keygen -b 521 -t ecdsa -f "$priv_key" -q -N "" -C "Flight Console API Key"
-  else
-    ssh-keygen -b 4096 -t rsa -f "$priv_key" -q -N "" -C "Flight Console API Key"
-  fi
+  ssh-keygen -b 521 -t ecdsa -f "$priv_key" -q -N "" -C "Flight Console API Key"
 
   # Ensure any existing public key is removed
   rm -f "$pub_key"


### PR DESCRIPTION
Flight Console API has been updated to generate `ecdsa` keys instead of `ssh-rsa` keys.