### PR TITLE
Add Profile & Hunter to Banner & Tips

### DIFF
--- a/builders/flight-hunter/opt/flight/etc/banner/banner.d/20-hunter-status.sh
+++ b/builders/flight-hunter/opt/flight/etc/banner/banner.d/20-hunter-status.sh
@@ -1,0 +1,57 @@
+#==============================================================================
+# Copyright (C) 2024-present Alces Flight Ltd.
+#
+# This file is part of Flight Starter.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Starter is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Starter. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Starter, please visit:
+# https://github.com/openflighthpc/flight-starter
+#==============================================================================
+(
+  # Only show for users with sudo
+  if ! sudo -l -n sudo >/dev/null 2>&1 ; then
+    return
+  fi
+
+  # Don't show unless status is set to "on" for cluster.status
+  if [[ ${flight_HUNTER_status:-'disabled'} != "enabled" ]] ; then
+    return
+  fi
+
+  # Set formatting
+  bold="$(tput bold)"
+  clr="$(tput sgr0)"
+  if [[ $TERM =~ "256color" ]]; then
+    white="$(tput setaf 7)"
+    bgblue="$(tput setab 68)"
+    bgred="$(tput setab 210)"
+    bgorange="$(tput setab 136)"
+    bggreen="$(tput setab 64)"
+  fi
+  echo -e "CLUSTER HUNTER STATUS:\n"
+  shopt -s nullglob
+
+  # Hunter info
+  printf "  ${bold}${white}${bggreen}Parsed:${clr}${bold}${white}${clr}\
+    $(ls ${flight_ROOT}/opt/hunter/var/parsed/ | wc -l)\
+    ${bold}${white}${bgorange}Buffer:${clr}${bold}${white}${clr}\
+    $(ls ${flight_ROOT}/opt/hunter/var/buffer/ | wc -l)\n"
+  echo ""
+)

--- a/builders/flight-hunter/opt/flight/etc/banner/banner.d/20-hunter-status.sh
+++ b/builders/flight-hunter/opt/flight/etc/banner/banner.d/20-hunter-status.sh
@@ -1,7 +1,7 @@
 #==============================================================================
 # Copyright (C) 2024-present Alces Flight Ltd.
 #
-# This file is part of Flight Starter.
+# This file is part of Flight Hunter.
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which is available at
@@ -9,7 +9,7 @@
 # terms made available by Alces Flight Ltd - please direct inquiries
 # about licensing to licensing@alces-flight.com.
 #
-# Flight Starter is distributed in the hope that it will be useful, but
+# Flight Hunter is distributed in the hope that it will be useful, but
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
 # IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
 # OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
@@ -17,12 +17,12 @@
 # details.
 #
 # You should have received a copy of the Eclipse Public License 2.0
-# along with Flight Starter. If not, see:
+# along with Flight Hunter. If not, see:
 #
 #  https://opensource.org/licenses/EPL-2.0
 #
-# For more information on Flight Starter, please visit:
-# https://github.com/openflighthpc/flight-starter
+# For more information on Flight Hunter, please visit:
+# https://github.com/openflighthpc/flight-hunter
 #==============================================================================
 (
   # Only show for users with sudo

--- a/builders/flight-hunter/opt/flight/etc/banner/tips.d/30-hunter.rc
+++ b/builders/flight-hunter/opt/flight/etc/banner/tips.d/30-hunter.rc
@@ -1,0 +1,9 @@
+################################################################################
+##
+## Flight Desktop
+## Copyright (c) 2024-present Alces Flight Ltd
+##
+################################################################################
+flight_TIP_command="flight hunter"
+flight_TIP_synopsis="only show if have comand"
+flight_TIP_root="true"

--- a/builders/flight-hunter/opt/flight/etc/banner/tips.d/30-hunter.rc
+++ b/builders/flight-hunter/opt/flight/etc/banner/tips.d/30-hunter.rc
@@ -1,9 +1,9 @@
 ################################################################################
 ##
-## Flight Desktop
+## Flight Hunter
 ## Copyright (c) 2024-present Alces Flight Ltd
 ##
 ################################################################################
 flight_TIP_command="flight hunter"
-flight_TIP_synopsis="only show if have comand"
+flight_TIP_synopsis="label and manage cluster node inventory"
 flight_TIP_root="true"

--- a/builders/flight-hunter/opt/flight/etc/settings.d/hunter.rc
+++ b/builders/flight-hunter/opt/flight/etc/settings.d/hunter.rc
@@ -1,7 +1,7 @@
 #==============================================================================
 # Copyright (C) 2024-present Alces Flight Ltd.
 #
-# This file is part of Flight Starter.
+# This file is part of Flight Hunter.
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which is available at
@@ -9,7 +9,7 @@
 # terms made available by Alces Flight Ltd - please direct inquiries
 # about licensing to licensing@alces-flight.com.
 #
-# Flight Starter is distributed in the hope that it will be useful, but
+# Flight Hunter is distributed in the hope that it will be useful, but
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
 # IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
 # OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
@@ -17,12 +17,12 @@
 # details.
 #
 # You should have received a copy of the Eclipse Public License 2.0
-# along with Flight Starter. If not, see:
+# along with Flight Hunter. If not, see:
 #
 #  https://opensource.org/licenses/EPL-2.0
 #
-# For more information on Flight Starter, please visit:
-# https://github.com/openflighthpc/flight-starter
+# For more information on Flight Hunter, please visit:
+# https://github.com/openflighthpc/flight-hunter
 #==============================================================================
 flight_SET_key=flight_HUNTER_status
 flight_SET_desc="${flight_STARTER_product} banner hunter status"

--- a/builders/flight-hunter/opt/flight/etc/settings.d/hunter.rc
+++ b/builders/flight-hunter/opt/flight/etc/settings.d/hunter.rc
@@ -1,0 +1,34 @@
+#==============================================================================
+# Copyright (C) 2024-present Alces Flight Ltd.
+#
+# This file is part of Flight Starter.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Starter is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Starter. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Starter, please visit:
+# https://github.com/openflighthpc/flight-starter
+#==============================================================================
+flight_SET_key=flight_HUNTER_status
+flight_SET_desc="${flight_STARTER_product} banner hunter status"
+flight_SET_info="
+ * To enable ${flight_STARTER_product} hunter status in banner of
+   active environment
+
+     ^flight set hunter on}
+"

--- a/builders/flight-profile/config/projects/flight-profile.rb
+++ b/builders/flight-profile/config/projects/flight-profile.rb
@@ -69,7 +69,10 @@ updated = original.sub(/^: VERSION: [[:graph:]]+$/, ": VERSION: #{VERSION}")
                   .sub(/^: SYNOPSIS:.*$/, ": SYNOPSIS: #{description}")
                   File.write(path, updated) unless original == updated
 
-extra_package_file 'opt/flight/libexec/commands/profile'
+require 'find'
+Find.find('opt') do |o|
+  extra_package_file(o) if File.file?(o)
+end
 
 config_file '/opt/flight/opt/profile/etc/config.yml'
 

--- a/builders/flight-profile/opt/flight/etc/banner/banner.d/21-profile-status.sh
+++ b/builders/flight-profile/opt/flight/etc/banner/banner.d/21-profile-status.sh
@@ -1,0 +1,64 @@
+#==============================================================================
+# Copyright (C) 2024-present Alces Flight Ltd.
+#
+# This file is part of Flight Profile.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Profile is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Profile. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Profile, please visit:
+# https://github.com/openflighthpc/flight-profile
+#==============================================================================
+(
+  # Only show for users with sudo
+  if ! sudo -l -n sudo >/dev/null 2>&1 ; then
+    return
+  fi
+
+  # Don't show unless status is set to "on" for cluster.status
+  if [[ ${flight_PROFILE_status:-'disabled'} != "enabled" ]] ; then
+    return
+  fi
+
+  # Set formatting
+  bold="$(tput bold)"
+  clr="$(tput sgr0)"
+  if [[ $TERM =~ "256color" ]]; then
+    white="$(tput setaf 7)"
+    bgblue="$(tput setab 68)"
+    bgred="$(tput setab 210)"
+    bgorange="$(tput setab 136)"
+    bggreen="$(tput setab 64)"
+  fi
+  echo -e "CLUSTER PROFILE STATUS:\n"
+  shopt -s nullglob
+
+  # Profile info
+  finished="$(grep -R exit_status ${flight_ROOT}/opt/profile/var/inventory/ |awk '{print $2}' |grep -v '^$')"
+  completed_nodes="$(echo "$finished" |grep '^0$' |grep -v '^$' -c )"
+  failed_nodes="$(echo "$finished" |grep -v '^0$' |grep -v '^$' -c )"
+  applying_nodes="$(grep -Rc 'last_action: apply' ${flight_ROOT}/opt/profile/var/inventory/ || echo -e '0')"
+  printf "  ${bold}${white}${bggreen}Completed:${clr}${bold}${white}${clr}\
+    $completed_nodes\
+    ${bold}${white}${bgorange}Applying:${clr}${bold}${white}${clr}\
+    $applying_nodes\
+    ${bold}${white}${bgred}Failed:${clr}${bold}${white}${clr}\
+    $failed_nodes\n"
+  shopt -u nullglob
+  echo ""
+)

--- a/builders/flight-profile/opt/flight/etc/banner/tips.d/40-profile.rc
+++ b/builders/flight-profile/opt/flight/etc/banner/tips.d/40-profile.rc
@@ -1,0 +1,9 @@
+################################################################################
+##
+## Flight Profile
+## Copyright (c) 2024-present Alces Flight Ltd
+##
+################################################################################
+flight_TIP_command="flight profile"
+flight_TIP_synopsis="configure and apply identities to nodes"
+flight_TIP_root="true"

--- a/builders/flight-profile/opt/flight/etc/settings.d/profile.rc
+++ b/builders/flight-profile/opt/flight/etc/settings.d/profile.rc
@@ -1,0 +1,34 @@
+#==============================================================================
+# Copyright (C) 2024-present Alces Flight Ltd.
+#
+# This file is part of Flight Profile.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Profile is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Profile. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Profile, please visit:
+# https://github.com/openflighthpc/flight-profile
+#==============================================================================
+flight_SET_key=flight_PROFILE_status
+flight_SET_desc="${flight_STARTER_product} banner profile status"
+flight_SET_info="
+ * To enable ${flight_STARTER_product} profile status in banner of
+   active environment
+
+     ^flight set profile on}
+"


### PR DESCRIPTION
Requires https://github.com/openflighthpc/flight-starter/pull/17 (for all) and https://github.com/openflighthpc/flight-profile/pull/124 (for profile banner)

This adds additional files to Profile & Hunter builders to add banner messages with current status of profile queue and hunter queue. It also adds these two commands to the TIPS menu in the banner.

Example when `flight set hunter on` and `flight set profile on` have been run:
<img width="592" alt="Screenshot 2024-01-18 at 16 01 59" src="https://github.com/openflighthpc/openflight-omnibus-builder/assets/27725639/94ce3ef9-41e3-4e61-b9e3-3fc4d23a4f03">
