### PR TITLE
Cloud dependencies for Flight Service

### DIFF
--- a/builders/flight-plugin-systemd-service/dist/flight-service.service
+++ b/builders/flight-plugin-systemd-service/dist/flight-service.service
@@ -28,8 +28,11 @@
 Description=OpenFlightHPC services
 After=syslog.target
 After=network-online.target
+After=cloud-final.service
 
 [Service]
+# Workaround for https://bugs.ruby-lang.org/issues/12695
+Environment="HOME=/"
 Type=oneshot
 SyslogIdentifier=flight-service
 RemainAfterExit=true
@@ -41,3 +44,4 @@ ExecStop=/opt/flight/bin/flight service stack stop
 
 [Install]
 WantedBy=multi-user.target
+WantedBy=cloud-init.target


### PR DESCRIPTION
This is based on the branch [`release/web-suite-overhaul`](https://github.com/openflighthpc/openflight-omnibus-builder/tree/release/web-suite-overhaul). 

Adds cloud services to systemd service file such that Flight Service will behave properly in environments where those services exist. 