### PR TITLE
Puma waits for 15 seconds instead of 10 seconds

### DIFF
--- a/share/config/software/update_puma_scripts.rb
+++ b/share/config/software/update_puma_scripts.rb
@@ -107,7 +107,7 @@ build do
     tool_bg #{flight_paths[:start_bin]} "$pidfile"
 
     # Wait up to 10ish seconds for puma to start
-    for _ in `seq 1 20`; do
+    for _ in `seq 1 30`; do
       sleep 0.5
       if [ -f "$pidfile" ]; then
         pid=$(cat "$pidfile" | tr -d "\\n")


### PR DESCRIPTION
Occasionally, APIs that we package (the motivation for this PR being Flight Profile API) take longer than the initially estimated 10 seconds for Puma to become responsive. Flight Profile API has been recorded taking roughly 10.5 seconds, which, very inconveniently, is just above the value currently hard-coded into the Puma script templates. While work _could_ be done to let this value be configured by the project using the shared `update_puma_scripts` software, it is much simpler to update the hard-coded value to 15 seconds, in case this issue ever arises with other Flight APIs.