### PR TITLE
Output landing-page compile to file instead of stdout

### DIFF
--- a/builders/flight-console-webapp/package-scripts/flight-console-webapp/postinst
+++ b/builders/flight-console-webapp/package-scripts/flight-console-webapp/postinst
@@ -25,7 +25,9 @@
 # For more information on OpenFlight Omnibus Builder, please visit:
 # https://github.com/openflighthpc/openflight-omnibus-builder
 #===============================================================================
-/opt/flight/bin/flight landing-page compile
+compile_log_dir=/opt/flight/var/log/package-scripts/
+mkdir -p $compile_log_dir
+/opt/flight/bin/flight landing-page compile >> $compile_log_dir/landing-page-compile.log 2>&1
 /opt/flight/bin/flight service reload www 1>/dev/null 2>&1
 
 exit 0

--- a/builders/flight-console-webapp/package-scripts/flight-console-webapp/postrm
+++ b/builders/flight-console-webapp/package-scripts/flight-console-webapp/postrm
@@ -25,7 +25,9 @@
 # For more information on OpenFlight Omnibus Builder, please visit:
 # https://github.com/openflighthpc/openflight-omnibus-builder
 #===============================================================================
-/opt/flight/bin/flight landing-page compile
+compile_log_dir=/opt/flight/var/log/package-scripts/
+mkdir -p $compile_log_dir
+/opt/flight/bin/flight landing-page compile >> $compile_log_dir/landing-page-compile.log 2>&1
 /opt/flight/bin/flight service reload www 1>/dev/null 2>&1
 
 exit 0

--- a/builders/flight-desktop-webapp/package-scripts/flight-desktop-webapp/postinst
+++ b/builders/flight-desktop-webapp/package-scripts/flight-desktop-webapp/postinst
@@ -25,7 +25,9 @@
 # For more information on OpenFlight Omnibus Builder, please visit:
 # https://github.com/openflighthpc/openflight-omnibus-builder
 #===============================================================================
-/opt/flight/bin/flight landing-page compile
+compile_log_dir=/opt/flight/var/log/package-scripts/
+mkdir -p $compile_log_dir
+/opt/flight/bin/flight landing-page compile >> $compile_log_dir/landing-page-compile.log 2>&1
 /opt/flight/bin/flight service reload www 1>/dev/null 2>&1
 
 exit 0

--- a/builders/flight-desktop-webapp/package-scripts/flight-desktop-webapp/postrm
+++ b/builders/flight-desktop-webapp/package-scripts/flight-desktop-webapp/postrm
@@ -25,7 +25,9 @@
 # For more information on OpenFlight Omnibus Builder, please visit:
 # https://github.com/openflighthpc/openflight-omnibus-builder
 #===============================================================================
-/opt/flight/bin/flight landing-page compile
+compile_log_dir=/opt/flight/var/log/package-scripts/
+mkdir -p $compile_log_dir
+/opt/flight/bin/flight landing-page compile >> $compile_log_dir/landing-page-compile.log 2>&1
 /opt/flight/bin/flight service reload www 1>/dev/null 2>&1
 
 exit 0

--- a/builders/flight-file-manager-webapp/package-scripts/flight-file-manager-webapp/postinst
+++ b/builders/flight-file-manager-webapp/package-scripts/flight-file-manager-webapp/postinst
@@ -25,7 +25,9 @@
 # For more information on OpenFlight Omnibus Builder, please visit:
 # https://github.com/openflighthpc/openflight-omnibus-builder
 #===============================================================================
-/opt/flight/bin/flight landing-page compile
+compile_log_dir=/opt/flight/var/log/package-scripts/
+mkdir -p $compile_log_dir
+/opt/flight/bin/flight landing-page compile >> $compile_log_dir/landing-page-compile.log 2>&1
 /opt/flight/bin/flight service reload www 1>/dev/null 2>&1
 
 exit 0

--- a/builders/flight-file-manager-webapp/package-scripts/flight-file-manager-webapp/postrm
+++ b/builders/flight-file-manager-webapp/package-scripts/flight-file-manager-webapp/postrm
@@ -25,7 +25,9 @@
 # For more information on OpenFlight Omnibus Builder, please visit:
 # https://github.com/openflighthpc/openflight-omnibus-builder
 #===============================================================================
-/opt/flight/bin/flight landing-page compile
+compile_log_dir=/opt/flight/var/log/package-scripts/
+mkdir -p $compile_log_dir
+/opt/flight/bin/flight landing-page compile >> $compile_log_dir/landing-page-compile.log 2>&1
 /opt/flight/bin/flight service reload www 1>/dev/null 2>&1
 
 exit 0

--- a/builders/flight-headnode-landing-page/package-scripts/flight-headnode-landing-page/postinst
+++ b/builders/flight-headnode-landing-page/package-scripts/flight-headnode-landing-page/postinst
@@ -29,7 +29,9 @@
 # `flight-www` may not be installed yet.  That is fine, as `flight-www` will
 # compile the landing page once it is installed.
 if [ -f /opt/flight/libexec/commands/landing-page ]; then
-    /opt/flight/bin/flight landing-page compile
+    compile_log_dir=/opt/flight/var/log/package-scripts/
+    mkdir -p $compile_log_dir
+    /opt/flight/bin/flight landing-page compile >> $compile_log_dir/landing-page-compile.log 2>&1
 fi
 
 exit 0

--- a/builders/flight-job-script-webapp/package-scripts/flight-job-script-webapp/postinst
+++ b/builders/flight-job-script-webapp/package-scripts/flight-job-script-webapp/postinst
@@ -25,7 +25,9 @@
 # For more information on OpenFlight Omnibus Builder, please visit:
 # https://github.com/openflighthpc/openflight-omnibus-builder
 #===============================================================================
-/opt/flight/bin/flight landing-page compile
+compile_log_dir=/opt/flight/var/log/package-scripts/
+mkdir -p $compile_log_dir
+/opt/flight/bin/flight landing-page compile >> $compile_log_dir/landing-page-compile.log 2>&1
 /opt/flight/bin/flight service reload www 1>/dev/null 2>&1
 
 exit 0

--- a/builders/flight-job-script-webapp/package-scripts/flight-job-script-webapp/postrm
+++ b/builders/flight-job-script-webapp/package-scripts/flight-job-script-webapp/postrm
@@ -25,7 +25,9 @@
 # For more information on OpenFlight Omnibus Builder, please visit:
 # https://github.com/openflighthpc/openflight-omnibus-builder
 #===============================================================================
-/opt/flight/bin/flight landing-page compile
+compile_log_dir=/opt/flight/var/log/package-scripts/
+mkdir -p $compile_log_dir
+/opt/flight/bin/flight landing-page compile >> $compile_log_dir/landing-page-compile.log 2>&1
 /opt/flight/bin/flight service reload www 1>/dev/null 2>&1
 
 exit 0

--- a/builders/flight-www/package-scripts/flight-www/postinst
+++ b/builders/flight-www/package-scripts/flight-www/postinst
@@ -34,7 +34,9 @@ if [ -d /opt/flight/opt/landing-page/www/overridden ]; then
              /opt/flight/opt/www/landing-page/
 fi
 
-/opt/flight/bin/flight landing-page compile
+compile_log_dir=/opt/flight/var/log/package-scripts/
+mkdir -p $compile_log_dir
+/opt/flight/bin/flight landing-page compile >> $compile_log_dir/landing-page-compile.log 2>&1
 
 
 # Rename the cron file used for automatic cert renewal.

--- a/builders/flight-www/package-scripts/flight-www/postrm
+++ b/builders/flight-www/package-scripts/flight-www/postrm
@@ -28,7 +28,7 @@
 
 # Reload the service if being removed due to upgrade
 # NOTE: Technically any reason but a full removal
-if [ "$1" != "0" ] || [ "$1" ~!= "remove" ]; then
+if [ "$1" != "0" ] && [ "$1" != "remove" ]; then
   # Stop the service
   /opt/flight/bin/flight service reload www >/dev/null 2>&1
 fi


### PR DESCRIPTION
This PR will redirect any occurrences of `landing-page compile` to a log file such that package installation process is not filled with spam but errors can still be located/addressed if occurring by referencing the log file. 


Additionally this PR includes a small fix for `flight-www` `postrm` where it was _trying_ to check that the process wasn't a removal (e.g. an upgrade) with incorrect logical operators (which would also cause a `[: ~!=: binary operator expected` in the event that the first argument is `0` [which is the case for RPM uninstalls]) 